### PR TITLE
Explicitly stop any ongoing servo command before sending move commands

### DIFF
--- a/airo-robots/airo_robots/manipulators/bimanual_position_manipulator.py
+++ b/airo-robots/airo_robots/manipulators/bimanual_position_manipulator.py
@@ -1,3 +1,4 @@
+import time
 from abc import ABC
 from typing import List, Optional, Union
 
@@ -169,3 +170,6 @@ if __name__ == "__main__":
         left_target_pose[0, 3] += 0.01
         right_target_pose[0, 3] += 0.01
         dual_arm.servo_to_tcp_pose(left_target_pose, right_target_pose, 0.2).wait(timeout=1)
+    left_target_pose[1, 3] -= 0.2
+    time.sleep(0.1)
+    dual_arm.move_linear_to_tcp_pose(left_target_pose, right_target_pose, 0.1).wait(timeout=100)

--- a/airo-robots/airo_robots/manipulators/hardware/ur_rtde.py
+++ b/airo-robots/airo_robots/manipulators/hardware/ur_rtde.py
@@ -74,6 +74,7 @@ class URrtde(PositionManipulator):
     def move_linear_to_tcp_pose(
         self, tcp_pose: HomogeneousMatrixType, linear_speed: Optional[float] = None
     ) -> AwaitableAction:
+        self.rtde_control.servoStop()  # stop any ongoing servo commands to avoid "another thread is controlling the robot" errors
         self._assert_pose_is_valid(tcp_pose)
         linear_speed = linear_speed or self.default_linear_speed
         self._assert_linear_speed_is_valid(linear_speed)
@@ -88,6 +89,7 @@ class URrtde(PositionManipulator):
     def move_to_tcp_pose(
         self, tcp_pose: HomogeneousMatrixType, joint_speed: Optional[float] = None
     ) -> AwaitableAction:
+        self.rtde_control.servoStop()  # stop any ongoing servo commands to avoid "another thread is controlling the robot" errors
         self._assert_pose_is_valid(tcp_pose)
         joint_speed = joint_speed or self.default_joint_speed
         # don't know what the leading axis will be, so check that joint speed < min(max_joint_speeds)
@@ -106,6 +108,7 @@ class URrtde(PositionManipulator):
     def move_to_joint_configuration(
         self, joint_configuration: JointConfigurationType, joint_speed: Optional[float] = None
     ) -> AwaitableAction:
+        self.rtde_control.servoStop()  # stop any ongoing servo commands to avoid "another thread is controlling the robot" errors
         # check joint limits
         self._assert_joint_configuration_is_valid(joint_configuration)
 


### PR DESCRIPTION
closes #44

Based on the Docs of the ur-rtde library and some testing. It is required to explicitly send a `servoStop` after servoing before sending move commands. We cannot simply do this in the servo methods as these might be called multiple times, so we call the `servoStop` in every move-method.