### PR TITLE
Add functionality to transform coco datasets

### DIFF
--- a/airo-dataset-tools/README.md
+++ b/airo-dataset-tools/README.md
@@ -21,9 +21,10 @@ We provide a [documented](airo_dataset_tools/cvat_labeling/readme.md) worklow fo
 
 We also provide a number of tools for working with COCO datasets:
 - visualisation using [FiftyOne](https://voxel51.com/)
-- resizing dataset images (TODO)
+- applying Albumentation transforms (e.g. resizing, flipping,...) to a COCO Keypoints dataset and its annotations, see [here](airo_dataset_tools/coco_tools/transform_dataset.py)
+- converting COCO instances to YOLO format (TODO)
 - combining COCO datasets (via datumaro)(TODO)
 
-These are all combined in the CLI, which you can access by running `airo-dataset-tools --help` from the command line.
+Most of the COCO tools are available in the CLI, which you can access by running `airo-dataset-tools --help` from the command line.
 
 

--- a/airo-dataset-tools/README.md
+++ b/airo-dataset-tools/README.md
@@ -1,7 +1,7 @@
 # airo-dataset-tools
 Package for working with datasets.
 
-[COCO](https://cocodataset.org/#format-data) is the preferred format for computer vision datasets.
+[COCO](https://cocodataset.org/#format-data) is the preferred format for computer vision datasets. We strictly follow their data format with 2 exceptions: segmentation masks are not required for Instance datasets, bounding boxes nor segmentation masks are required for keypoint datasets. This is to limit labeling effort for real-world datasets where you don't always need all annotation types.
 
 Other formats will are added if they are needed for dataset creation (think the format of a labeling tool) or for consumption of the dataset (think the YOLO format for training an object detector). Besides datasets, we also provide tools for other persistent data such as camera intrinsics and extrinsics.
 

--- a/airo-dataset-tools/airo_dataset_tools/cli.py
+++ b/airo-dataset-tools/airo_dataset_tools/cli.py
@@ -67,10 +67,10 @@ def resize_coco_keypoints_dataset(annotations_json_path: str, width: int, height
     coco_dataset_dir = os.path.dirname(annotations_json_path)
     annotations_file_name = os.path.basename(annotations_json_path)
     dataset_parent_dir = os.path.dirname(coco_dataset_dir)
-    transformed_dataset_dir = os.path.join(dataset_parent_dir, f"_resized_{width}x{height}")
+    transformed_dataset_dir = os.path.join(dataset_parent_dir, f"{annotations_file_name}_resized_{width}x{height}")
     os.makedirs(transformed_dataset_dir, exist_ok=True)
 
-    transforms = [A.Resize(width, height)]
+    transforms = [A.Resize(height, width)]
     coco_json = json.load(open(annotations_json_path, "r"))
     coco_dataset = CocoKeypointsDataset(**coco_json)
     transformed_dataset = apply_transform_to_coco_dataset(

--- a/airo-dataset-tools/airo_dataset_tools/cli.py
+++ b/airo-dataset-tools/airo_dataset_tools/cli.py
@@ -39,6 +39,7 @@ def convert_cvat_to_coco_cli(cvat_xml_file: str, add_bbox: bool, add_segmentatio
     """Convert CVAT XML to COCO keypoints json"""
     coco = cvat_image_to_coco(cvat_xml_file, add_bbox=add_bbox, add_segmentation=add_segmentation)
     path = os.path.dirname(cvat_xml_file)
-    path = os.path.join(path, "coco.json")
+    filename = os.path.basename(cvat_xml_file)
+    path = os.path.join(path, filename.split(".")[0] + ".json")
     with open(path, "w") as file:
         json.dump(coco, file)

--- a/airo-dataset-tools/airo_dataset_tools/cli.py
+++ b/airo-dataset-tools/airo_dataset_tools/cli.py
@@ -4,8 +4,11 @@ import json
 import os
 from typing import List, Optional
 
+import albumentations as A
 import click
+from airo_dataset_tools.coco_tools.transform_dataset import apply_transform_to_coco_dataset
 from airo_dataset_tools.cvat_labeling.convert_cvat_to_coco import cvat_image_to_coco
+from airo_dataset_tools.data_parsers.coco import CocoKeypointsDataset
 from airo_dataset_tools.fiftyone_viewer import view_coco_dataset
 
 
@@ -16,7 +19,12 @@ def cli() -> None:
 
 @cli.command(name="fiftyone-coco-viewer")  # no help, takes the docstring of the function.
 @click.argument("annotations-json-path", type=click.Path(exists=True))
-@click.option("--dataset-dir", required=False, type=click.Path(exists=True))
+@click.option(
+    "--dataset-dir",
+    required=False,
+    type=click.Path(exists=True),
+    help="optional directory relative to which the image paths in the coco dataset are specified",
+)
 @click.option(
     "--label-types",
     "-l",
@@ -43,3 +51,32 @@ def convert_cvat_to_coco_cli(cvat_xml_file: str, add_bbox: bool, add_segmentatio
     path = os.path.join(path, filename.split(".")[0] + ".json")
     with open(path, "w") as file:
         json.dump(coco, file)
+
+
+@cli.command(name="resize-coco-keypoints-dataset")
+@click.argument("annotations-json-path", type=click.Path(exists=True))
+@click.option("--width", type=int, required=True)
+@click.option("--height", type=int, required=True)
+def resize_coco_keypoints_dataset(annotations_json_path: str, width: int, height: int) -> None:
+    """Resize a COCO dataset. Will create a new directory with the resized dataset on the same level as the original dataset.
+    Dataset is assumed to be
+    /dir
+        annotations.json # contains relative paths w.r.t. /dir
+        ...
+    """
+    coco_dataset_dir = os.path.dirname(annotations_json_path)
+    annotations_file_name = os.path.basename(annotations_json_path)
+    dataset_parent_dir = os.path.dirname(coco_dataset_dir)
+    transformed_dataset_dir = os.path.join(dataset_parent_dir, f"_resized_{width}x{height}")
+    os.makedirs(transformed_dataset_dir, exist_ok=True)
+
+    transforms = [A.Resize(width, height)]
+    coco_json = json.load(open(annotations_json_path, "r"))
+    coco_dataset = CocoKeypointsDataset(**coco_json)
+    transformed_dataset = apply_transform_to_coco_dataset(
+        transforms, coco_dataset, coco_dataset_dir, transformed_dataset_dir
+    )
+
+    transformed_dataset_dict = transformed_dataset.dict(exclude_none=True)
+    with open(os.path.join(transformed_dataset_dir, annotations_file_name), "w") as f:
+        json.dump(transformed_dataset_dict, f)

--- a/airo-dataset-tools/airo_dataset_tools/coco_tools/transform_dataset.py
+++ b/airo-dataset-tools/airo_dataset_tools/coco_tools/transform_dataset.py
@@ -15,7 +15,7 @@ from airo_dataset_tools.segmentation_mask_converter import BinarySegmentationMas
 from PIL import Image
 
 
-def apply_transform_to_coco_dataset(  # noqa: C901
+def apply_transform_to_coco_dataset(  # type: ignore # noqa: C901
     transforms: List[A.DualTransform],
     coco_dataset: CocoInstancesDataset,
     image_path: str,

--- a/airo-dataset-tools/airo_dataset_tools/coco_tools/transform_dataset.py
+++ b/airo-dataset-tools/airo_dataset_tools/coco_tools/transform_dataset.py
@@ -1,0 +1,145 @@
+import os
+from typing import Callable, List
+
+import albumentations as A
+import numpy as np
+import tqdm
+from airo_dataset_tools.data_parsers.coco import CocoKeypointAnnotation, CocoKeypointsDataset
+from airo_dataset_tools.segmentation_mask_converter import BinarySegmentationMask
+from PIL import Image
+
+
+def apply_transform_to_coco_dataset(
+    transforms: List[A.DualTransform],
+    coco_dataset: CocoKeypointsDataset,
+    image_path: str,
+    target_image_path: str,
+    image_name_filter: Callable[[str], bool] = None,
+) -> CocoKeypointsDataset:
+    """Apply a sequence of albumentations transforms to a coco dataset, transforming images, keypoints, bounding boxes and segmentation masks.
+
+    Args:
+        transforms (List[A.DualTransform]): _description_
+        coco_dataset (CocoKeypointsDataset): _description_
+        image_path (str): folder relative to which the image paths in the coco dataset are specified
+        target_image_path (str): folder relative to which the image paths in the transformed coco dataset will be specified
+        image_name_filter (Callable[[str], bool], optional): optional filter for which images to transform based on their full path. Defaults to None.
+
+    Returns:
+        CocoKeypointsDataset: _description_
+    """
+
+    transform = A.Compose(
+        transforms,
+        keypoint_params=A.KeypointParams(format="xy", remove_invisible=False),
+        bbox_params=A.BboxParams(format="coco", label_fields=["bbox_dummy_labels"]),
+    )
+
+    # create mappings between images & all corresponding annotations
+    image_object_id_to_image_mapping = {image.id: image for image in coco_dataset.images}
+    image_to_annotations_mapping = {coco_dataset.images[i]: [] for i in range(len(coco_dataset.images))}
+    for annotation in coco_dataset.annotations:
+        image_to_annotations_mapping[image_object_id_to_image_mapping[annotation.image_id]].append(annotation)
+
+    for coco_image, annotations in tqdm.tqdm(image_to_annotations_mapping.items()):
+        if image_name_filter is not None and image_name_filter(coco_image.file_name):
+            print(f"skipping image {coco_image.file_name}")
+            continue
+
+        # load image
+        image = Image.open(os.path.join(image_path, coco_image.file_name)).convert(
+            "RGB"
+        )  # convert to RGB to avoid problems with PNG images
+        image = np.array(image)
+        print(image.shape)
+
+        # combine annotations for all Annotation Instances related to the image
+        # to transform them together with the image
+        all_keypoints_xy = []
+        all_bboxes = []
+        all_masks = []
+        for annotation in annotations:
+            assert isinstance(annotation, CocoKeypointAnnotation)
+            all_keypoints_xy.extend(annotation.keypoints)
+            all_bboxes.append(annotation.bbox)
+            # convert segmentation to binary mask
+            mask = annotation.segmentation
+            bitmap = BinarySegmentationMask.from_coco_segmentation_mask(
+                mask, coco_image.width, coco_image.height
+            ).bitmap
+            print(bitmap.shape)
+            all_masks.append(bitmap)
+
+        # convert coco keypoints to list of (x,y) keypoints
+        all_keypoints_xy = [all_keypoints_xy[i : i + 2] for i in range(0, len(all_keypoints_xy), 3)]
+
+        transformed = transform(
+            image=image,
+            keypoints=all_keypoints_xy,
+            bboxes=all_bboxes,
+            masks=all_masks,
+            bbox_dummy_labels=[0 for _ in all_bboxes],
+        )
+
+        # save transformed image
+        transformed_image = transformed["image"]
+        transformed_image = Image.fromarray(transformed_image)
+        transformed_image_dir = os.path.join(target_image_path, os.path.dirname(coco_image.file_name))
+        if not os.path.exists(transformed_image_dir):
+            os.makedirs(transformed_image_dir)
+        transformed_image.save(os.path.join(target_image_path, coco_image.file_name))
+
+        # change the metadata of the image coco object
+        coco_image.width = transformed_image.width
+        coco_image.height = transformed_image.height
+
+        # store all modified annotations back into the coco dataset
+        all_transformed_keypoints_xy = transformed["keypoints"]
+        all_transformed_bboxes = transformed["bboxes"]
+        all_transformed_masks = transformed["masks"]
+        for annotation in annotations:
+            transformed_keypoints = all_transformed_keypoints_xy[: len(annotation.keypoints) // 3]
+            all_transformed_keypoints_xy = all_transformed_keypoints_xy[len(annotation.keypoints) // 3 :]
+            transformed_bbox = all_transformed_bboxes.pop(0)  # exactly one bbox per annotation
+            transformed_segmentations = all_transformed_masks.pop(0)  # exactly one segmentation per annotation
+
+            # set keypoints that are no longer in image to (0,0,0)
+            for i, kp in enumerate(transformed_keypoints):
+                if 0 <= kp[0] < coco_image.width and 0 <= kp[1] < coco_image.height:
+                    # add original visibility flag
+                    transformed_keypoints[i] = [kp[0], kp[1], annotation.keypoints[i * 3 + 2]]
+                else:
+                    transformed_keypoints[i] = [0.0, 0.0, 0]
+
+            flattened_transformed_keypoints = [i for kp in transformed_keypoints for i in kp]
+            annotation.keypoints = flattened_transformed_keypoints
+            annotation.bbox = transformed_bbox
+            Image.fromarray(transformed_segmentations).save(f"test_{annotation.id}.png")
+            annotation.segmentation = BinarySegmentationMask(transformed_segmentations).as_polygon
+
+    return coco_dataset
+
+
+if __name__ == "__main__":
+    """example usage of the above function to resize all images in a coco dataset.
+    Copy the following lines into your own codebase and modify as needed."""
+    import json
+    import pathlib
+
+    path = pathlib.Path(__file__).parents[1] / "cvat_labeling" / "example" / "coco.json"
+
+    coco_json_path = str(path)
+    coco_dir = os.path.dirname(coco_json_path)
+    coco_file_name = os.path.basename(coco_json_path)
+    coco_target_dir = os.path.join(os.path.dirname(coco_dir), "transformed")
+    os.makedirs(coco_target_dir, exist_ok=True)
+
+    transforms = [A.Resize(128, 128)]
+
+    coco_json = json.load(open(coco_json_path, "r"))
+    coco_dataset = CocoKeypointsDataset(**coco_json)
+    transformed_dataset = apply_transform_to_coco_dataset(transforms, coco_dataset, coco_dir, coco_target_dir)
+
+    transformed_dataset_dict = transformed_dataset.dict(exclude_none=True)
+    with open(os.path.join(coco_target_dir, coco_file_name), "w") as f:
+        json.dump(transformed_dataset_dict, f)

--- a/airo-dataset-tools/airo_dataset_tools/coco_tools/transform_dataset.py
+++ b/airo-dataset-tools/airo_dataset_tools/coco_tools/transform_dataset.py
@@ -139,7 +139,7 @@ def apply_transform_to_coco_dataset(  # noqa: C901
 
             if transform_segmentation:
                 transformed_segmentations = all_transformed_masks.pop(0)  # exactly one segmentation per annotation
-            annotation.segmentation = BinarySegmentationMask(transformed_segmentations).as_polygon
+                annotation.segmentation = BinarySegmentationMask(transformed_segmentations).as_polygon
 
     return coco_dataset
 

--- a/airo-dataset-tools/airo_dataset_tools/cvat_labeling/example/coco.json
+++ b/airo-dataset-tools/airo_dataset_tools/cvat_labeling/example/coco.json
@@ -28,25 +28,25 @@
             "id": 1,
             "width": 600,
             "height": 338,
-            "file_name": "1.png"
+            "file_name": "images/1.png"
         },
         {
             "id": 2,
             "width": 500,
             "height": 281,
-            "file_name": "2.png"
+            "file_name": "images/2.png"
         },
         {
             "id": 3,
             "width": 256,
             "height": 256,
-            "file_name": "3.jpeg"
+            "file_name": "images/3.jpeg"
         },
         {
             "id": 4,
             "width": 600,
             "height": 338,
-            "file_name": "4.png"
+            "file_name": "images/4.png"
         }
     ],
     "annotations": [

--- a/airo-dataset-tools/airo_dataset_tools/cvat_labeling/readme.md
+++ b/airo-dataset-tools/airo_dataset_tools/cvat_labeling/readme.md
@@ -34,6 +34,7 @@ some tips for labeling:
 - easier to label 1 label for the entire dataset and then do another label instead of switching between labels.
 - save every now and then
 - test the conversion script early enough to avoid wasting label effort.
+- enable autosave to avoid losing annotations when your ssh connection drops
 
 ### Converting cvat annotations to COCO annotations
 Once you have the cvat annotations you can export them under the `CVAT Images 1.1` format, which will generate an xml file. This xml file can then be converted to a COCO Keypoints dataset, using the CLI of this package: `airo-dataset-tools convert-cvat-to-coco-keypoints <xml-file-path>`.
@@ -47,6 +48,7 @@ For the example in this module, it would look like this:
 - follow the steps [here](https://opencv.github.io/cvat/docs/administration/basics/installation/) to clone the repo and install the dependencies.
 - add local share for your mount where you by creating an `docker-compose-override.yml` file, as described [here](https://opencv.github.io/cvat/v1.6.0/docs/administration/basics/installation/#share-path)
 - run `CVAT_VERSION=<your-version> docker-compose up -d` to start CVAT. It will restart if the containers have been shut down (e.g. when rebooting) so it should be always up and running.
+- If you need serverless support, for example to label with Segment Anything, take a look at the docs [here](TODO)
 - create a superuser as described [here](https://opencv.github.io/cvat/docs/administration/basics/admin-account/).
 - start using cvat by browsing to [localhost:8080](localhost:8080).
 

--- a/airo-dataset-tools/airo_dataset_tools/data_parsers/coco.py
+++ b/airo-dataset-tools/airo_dataset_tools/data_parsers/coco.py
@@ -101,7 +101,7 @@ class CocoInstanceAnnotation(BaseModel):
     image_id: ImageID
     category_id: CategoryID
 
-    bbox: Tuple[float, float, float, float]
+    bbox: Optional[Tuple[float, float, float, float]]
 
     segmentation: Optional[Segmentation] = None
     area: Optional[float] = None

--- a/airo-dataset-tools/airo_dataset_tools/data_parsers/coco.py
+++ b/airo-dataset-tools/airo_dataset_tools/data_parsers/coco.py
@@ -101,31 +101,26 @@ class CocoInstanceAnnotation(BaseModel):
     image_id: ImageID
     category_id: CategoryID
 
-    # make segmentation and bbox optional by having a non-sensible default
-    segmentation: Segmentation
-    area: float
     bbox: Tuple[float, float, float, float]
-    iscrowd: IsCrowd
+
+    segmentation: Optional[Segmentation] = None
+    area: Optional[float] = None
+    iscrowd: Optional[IsCrowd] = None
 
     @validator("iscrowd")
     def iscrowd_must_be_binary(cls, v: IsCrowd) -> IsCrowd:
+        if v is None:
+            return None
         assert v in [0, 1]
         return v
-
-
-DEFAULT_COCO_SEGMENTATION = [[0.0, 0.0, 0.0, 0.0]]
-DEFAULT_COCO_BBOX = (0.0, 0.0, 0.0, 0.0)
 
 
 class CocoKeypointAnnotation(CocoInstanceAnnotation):
     keypoints: Keypoints
     num_keypoints: Optional[int]
 
-    # make segmentation and bbox optional by having a non-sensible default
-    segmentation: Segmentation = DEFAULT_COCO_SEGMENTATION
-    area: float = 0.0
-    bbox: Tuple[float, float, float, float] = DEFAULT_COCO_BBOX
-    iscrowd: IsCrowd = 0
+    # make bbox optional
+    bbox: Optional[Tuple[float, float, float, float]] = None
 
     @validator("keypoints")
     def keypoints_must_be_multiple_of_three(cls, v: Keypoints) -> Keypoints:

--- a/airo-dataset-tools/airo_dataset_tools/data_parsers/coco.py
+++ b/airo-dataset-tools/airo_dataset_tools/data_parsers/coco.py
@@ -82,6 +82,7 @@ class CocoImage(BaseModel):
     flicker_url: Optional[Url] = None
     coco_url: Optional[Url] = None
     date_captured: Optional[Datetime] = None
+    __hash__ = object.__hash__  # make hashable for use in set
 
 
 class CocoCategory(BaseModel):
@@ -112,14 +113,18 @@ class CocoInstanceAnnotation(BaseModel):
         return v
 
 
+DEFAULT_COCO_SEGMENTATION = [[0.0, 0.0, 0.0, 0.0]]
+DEFAULT_COCO_BBOX = (0.0, 0.0, 0.0, 0.0)
+
+
 class CocoKeypointAnnotation(CocoInstanceAnnotation):
     keypoints: Keypoints
     num_keypoints: Optional[int]
 
     # make segmentation and bbox optional by having a non-sensible default
-    segmentation: Segmentation = [[0.0, 0.0, 0.0, 0.0]]
+    segmentation: Segmentation = DEFAULT_COCO_SEGMENTATION
     area: float = 0.0
-    bbox: Tuple[float, float, float, float] = (0.0, 0.0, 0.0, 0.0)
+    bbox: Tuple[float, float, float, float] = DEFAULT_COCO_BBOX
     iscrowd: IsCrowd = 0
 
     @validator("keypoints")

--- a/airo-dataset-tools/airo_dataset_tools/segmentation_mask_converter.py
+++ b/airo-dataset-tools/airo_dataset_tools/segmentation_mask_converter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import List, Tuple
 
+import cv2
 import numpy as np
 from airo_dataset_tools.data_parsers.coco import Polygon, RLEDict, Segmentation
 from pycocotools import mask
@@ -16,6 +17,7 @@ class BinarySegmentationMask:
 
     def __init__(self, bitmap: np.ndarray):
         assert np.array_equal((bitmap == 1.0) * 1.0, bitmap), "bitmap must be 1 or 0 numpy array"
+        bitmap = bitmap.astype(np.uint8)
         self.bitmap = bitmap
 
     @classmethod
@@ -56,7 +58,18 @@ class BinarySegmentationMask:
 
     @property
     def as_polygon(self) -> List[Polygon]:
-        raise NotImplementedError
+        # from https://github.com/cocodataset/cocoapi/issues/476#issuecomment-871804850
+        contours, _ = cv2.findContours(self.bitmap, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
+        segmentation = []
+        valid_poly = 0
+        for contour in contours:
+            # Valid polygons have >= 6 coordinates (3 points)
+            if contour.size >= 6:
+                segmentation.append(contour.astype(float).flatten().tolist())
+                valid_poly += 1
+        if valid_poly == 0:
+            raise ValueError
+        return segmentation
 
     @property
     def as_uncompressed_rle(self) -> RLEDict:
@@ -70,3 +83,10 @@ class BinarySegmentationMask:
         assert isinstance(encoded_rle["counts"], bytes)
         encoded_rle["counts"] = encoded_rle["counts"].decode("utf-8")
         return encoded_rle
+
+
+# if __name__ == "__main__":
+#     mask = np.zeros((10, 10)).astype(np.uint8)
+#     mask[1:3] = 1
+#     print(mask)
+#     print(BinarySegmentationMask(mask).as_polygon)

--- a/airo-dataset-tools/airo_dataset_tools/segmentation_mask_converter.py
+++ b/airo-dataset-tools/airo_dataset_tools/segmentation_mask_converter.py
@@ -47,7 +47,7 @@ class BinarySegmentationMask:
 
     @property
     def area(self) -> float:
-        return mask.area(self.as_compressed_rle)
+        return float(mask.area(self.as_compressed_rle))
 
     @property
     def bbox(self) -> Tuple[float, float, float, float]:

--- a/airo-dataset-tools/setup.py
+++ b/airo-dataset-tools/setup.py
@@ -14,6 +14,8 @@ setuptools.setup(
         "xmltodict",
         "tqdm",
         "fiftyone",  # visualization
+        "albumentations",
+        "opencv-python",
     ],
     packages=find_packages(),
     entry_points={

--- a/airo-dataset-tools/setup.py
+++ b/airo-dataset-tools/setup.py
@@ -16,6 +16,8 @@ setuptools.setup(
         "fiftyone",  # visualization
         "albumentations",
         "opencv-python",
+        "Pillow",
+        "types-Pillow",
     ],
     packages=find_packages(),
     entry_points={

--- a/airo-dataset-tools/test/test_coco_load.py
+++ b/airo-dataset-tools/test/test_coco_load.py
@@ -61,3 +61,30 @@ def test_coco_load_instances_incorrectly():
         data = json.load(file)
         with pytest.raises(Exception):
             CocoKeypointsDataset(**data)
+
+
+def test_coco_load_instances_no_segmasks():
+    """Test whether we can correctly load the partial instances_val2017 dataset without segmentations."""
+    test_dir = os.path.dirname(os.path.realpath(__file__))
+    annotations = os.path.join(test_dir, "test_data/person_keypoints_val2017_small_no_segmentations.json")
+
+    with open(annotations, "r") as file:
+        data = json.load(file)
+        coco_instances = CocoKeypointsDataset(**data)
+        # Check a few known lengths to ensure that all elements were loaded
+        assert len(coco_instances.images) == 2
+
+
+def test_coco_load_keypoints_no_bboxes():
+    """Test whether we can correctly load the partial person_keypoints_val2017 dataset without bounding boxes."""
+    test_dir = os.path.dirname(os.path.realpath(__file__))
+    annotations = os.path.join(test_dir, "test_data/person_keypoints_val2017_small_no_bbox.json")
+
+    with open(annotations, "r") as file:
+        data = json.load(file)
+        coco_keypoints = CocoKeypointsDataset(**data)
+        assert len(coco_keypoints.images) == 2
+        assert len(coco_keypoints.categories) == 1
+        assert len(coco_keypoints.annotations) == 2
+
+        assert isinstance(coco_keypoints.categories[0], CocoKeypointCategory)

--- a/airo-dataset-tools/test/test_data/person_keypoints_val2017_small_no_bbox.json
+++ b/airo-dataset-tools/test/test_data/person_keypoints_val2017_small_no_bbox.json
@@ -1,0 +1,169 @@
+{
+  "info": {
+    "description": "COCO 2017 Dataset",
+    "url": "http://cocodataset.org",
+    "version": "1.0",
+    "year": 2017,
+    "contributor": "COCO Consortium",
+    "date_created": "2017/09/01"
+  },
+  "licenses": [
+    {
+      "url": "http://creativecommons.org/licenses/by-nc-sa/2.0/",
+      "id": 1,
+      "name": "Attribution-NonCommercial-ShareAlike License"
+    },
+    {
+      "url": "http://creativecommons.org/licenses/by-nc/2.0/",
+      "id": 2,
+      "name": "Attribution-NonCommercial License"
+    },
+    {
+      "url": "http://creativecommons.org/licenses/by-nc-nd/2.0/",
+      "id": 3,
+      "name": "Attribution-NonCommercial-NoDerivs License"
+    },
+    {
+      "url": "http://creativecommons.org/licenses/by/2.0/",
+      "id": 4,
+      "name": "Attribution License"
+    },
+    {
+      "url": "http://creativecommons.org/licenses/by-sa/2.0/",
+      "id": 5,
+      "name": "Attribution-ShareAlike License"
+    },
+    {
+      "url": "http://creativecommons.org/licenses/by-nd/2.0/",
+      "id": 6,
+      "name": "Attribution-NoDerivs License"
+    },
+    {
+      "url": "http://flickr.com/commons/usage/",
+      "id": 7,
+      "name": "No known copyright restrictions"
+    },
+    {
+      "url": "http://www.usa.gov/copyright.shtml",
+      "id": 8,
+      "name": "United States Government Work"
+    }
+  ],
+  "images": [
+    {
+      "license": 4,
+      "file_name": "000000397133.jpg",
+      "coco_url": "http://images.cocodataset.org/val2017/000000397133.jpg",
+      "height": 427,
+      "width": 640,
+      "date_captured": "2013-11-14 17:02:52",
+      "flickr_url": "http://farm7.staticflickr.com/6116/6255196340_da26cf2c9e_z.jpg",
+      "id": 397133
+    },
+    {
+      "license": 1,
+      "file_name": "000000037777.jpg",
+      "coco_url": "http://images.cocodataset.org/val2017/000000037777.jpg",
+      "height": 230,
+      "width": 352,
+      "date_captured": "2013-11-14 20:55:31",
+      "flickr_url": "http://farm9.staticflickr.com/8429/7839199426_f6d48aa585_z.jpg",
+      "id": 37777
+    }
+  ],
+  "annotations": [
+    {
+      "segmentation": [
+        [
+          446.71, 70.66, 466.07, 72.89, 471.28, 78.85, 473.51, 88.52, 473.51,
+          98.2, 462.34, 111.6, 475.74, 126.48, 484.67, 136.16, 494.35, 157.74,
+          496.58, 174.12, 498.07, 182.31, 485.42, 189.75, 474.25, 189.01,
+          470.53, 202.4, 475.74, 337.12, 469.04, 347.54, 455.65, 343.08, 450.44,
+          323.72, 441.5, 255.99, 433.32, 250.04, 406.52, 340.1, 397.59, 344.56,
+          388.66, 330.42, 408.01, 182.31, 396.85, 186.77, 392.38, 177.84, 389.4,
+          166.68, 390.89, 147.32, 418.43, 119.04, 434.06, 111.6, 429.6, 98.94,
+          428.85, 81.08, 441.5, 72.89, 443.74, 69.92
+        ]
+      ],
+      "num_keypoints": 13,
+      "area": 17376.91885,
+      "iscrowd": 0,
+      "keypoints": [
+        433, 94, 2, 434, 90, 2, 0, 0, 0, 443, 98, 2, 0, 0, 0, 420, 128, 2, 474,
+        133, 2, 396, 162, 2, 489, 173, 2, 0, 0, 0, 0, 0, 0, 419, 214, 2, 458,
+        215, 2, 411, 274, 2, 458, 273, 2, 402, 333, 2, 465, 334, 2
+      ],
+      "image_id": 397133,
+      "category_id": 1,
+      "id": 200887
+    },
+    {
+      "segmentation": [
+        [
+          0.43, 299.58, 2.25, 299.58, 9.05, 287.78, 32.66, 299.13, 39.01, 296.4,
+          48.09, 290.96, 43.55, 286.87, 62.16, 291.86, 61.25, 286.87, 37.65,
+          279.15, 18.13, 272.8, 0, 262.81
+        ]
+      ],
+      "num_keypoints": 1,
+      "area": 1037.7819,
+      "iscrowd": 0,
+      "keypoints": [
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 9, 277, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0
+      ],
+      "image_id": 397133,
+      "bbox": [0, 262.81, 62.16, 36.77],
+      "category_id": 1,
+      "id": 1218137
+    }
+  ],
+  "categories": [
+    {
+      "supercategory": "person",
+      "id": 1,
+      "name": "person",
+      "keypoints": [
+        "nose",
+        "left_eye",
+        "right_eye",
+        "left_ear",
+        "right_ear",
+        "left_shoulder",
+        "right_shoulder",
+        "left_elbow",
+        "right_elbow",
+        "left_wrist",
+        "right_wrist",
+        "left_hip",
+        "right_hip",
+        "left_knee",
+        "right_knee",
+        "left_ankle",
+        "right_ankle"
+      ],
+      "skeleton": [
+        [16, 14],
+        [14, 12],
+        [17, 15],
+        [15, 13],
+        [12, 13],
+        [6, 12],
+        [7, 13],
+        [6, 7],
+        [6, 8],
+        [7, 9],
+        [8, 10],
+        [9, 11],
+        [2, 3],
+        [1, 2],
+        [1, 3],
+        [2, 4],
+        [3, 5],
+        [4, 6],
+        [5, 7]
+      ]
+    }
+  ]
+}

--- a/airo-dataset-tools/test/test_data/person_keypoints_val2017_small_no_segmentations.json
+++ b/airo-dataset-tools/test/test_data/person_keypoints_val2017_small_no_segmentations.json
@@ -1,0 +1,158 @@
+{
+  "info": {
+    "description": "COCO 2017 Dataset",
+    "url": "http://cocodataset.org",
+    "version": "1.0",
+    "year": 2017,
+    "contributor": "COCO Consortium",
+    "date_created": "2017/09/01"
+  },
+  "licenses": [
+    {
+      "url": "http://creativecommons.org/licenses/by-nc-sa/2.0/",
+      "id": 1,
+      "name": "Attribution-NonCommercial-ShareAlike License"
+    },
+    {
+      "url": "http://creativecommons.org/licenses/by-nc/2.0/",
+      "id": 2,
+      "name": "Attribution-NonCommercial License"
+    },
+    {
+      "url": "http://creativecommons.org/licenses/by-nc-nd/2.0/",
+      "id": 3,
+      "name": "Attribution-NonCommercial-NoDerivs License"
+    },
+    {
+      "url": "http://creativecommons.org/licenses/by/2.0/",
+      "id": 4,
+      "name": "Attribution License"
+    },
+    {
+      "url": "http://creativecommons.org/licenses/by-sa/2.0/",
+      "id": 5,
+      "name": "Attribution-ShareAlike License"
+    },
+    {
+      "url": "http://creativecommons.org/licenses/by-nd/2.0/",
+      "id": 6,
+      "name": "Attribution-NoDerivs License"
+    },
+    {
+      "url": "http://flickr.com/commons/usage/",
+      "id": 7,
+      "name": "No known copyright restrictions"
+    },
+    {
+      "url": "http://www.usa.gov/copyright.shtml",
+      "id": 8,
+      "name": "United States Government Work"
+    }
+  ],
+  "images": [
+    {
+      "license": 4,
+      "file_name": "000000397133.jpg",
+      "coco_url": "http://images.cocodataset.org/val2017/000000397133.jpg",
+      "height": 427,
+      "width": 640,
+      "date_captured": "2013-11-14 17:02:52",
+      "flickr_url": "http://farm7.staticflickr.com/6116/6255196340_da26cf2c9e_z.jpg",
+      "id": 397133
+    },
+    {
+      "license": 1,
+      "file_name": "000000037777.jpg",
+      "coco_url": "http://images.cocodataset.org/val2017/000000037777.jpg",
+      "height": 230,
+      "width": 352,
+      "date_captured": "2013-11-14 20:55:31",
+      "flickr_url": "http://farm9.staticflickr.com/8429/7839199426_f6d48aa585_z.jpg",
+      "id": 37777
+    }
+  ],
+  "annotations": [
+    {
+      "num_keypoints": 13,
+      "area": 17376.91885,
+      "iscrowd": 0,
+      "keypoints": [
+        433, 94, 2, 434, 90, 2, 0, 0, 0, 443, 98, 2, 0, 0, 0, 420, 128, 2, 474,
+        133, 2, 396, 162, 2, 489, 173, 2, 0, 0, 0, 0, 0, 0, 419, 214, 2, 458,
+        215, 2, 411, 274, 2, 458, 273, 2, 402, 333, 2, 465, 334, 2
+      ],
+      "image_id": 397133,
+      "bbox": [388.66, 69.92, 109.41, 277.62],
+      "category_id": 1,
+      "id": 200887
+    },
+    {
+      "segmentation": [
+        [
+          0.43, 299.58, 2.25, 299.58, 9.05, 287.78, 32.66, 299.13, 39.01, 296.4,
+          48.09, 290.96, 43.55, 286.87, 62.16, 291.86, 61.25, 286.87, 37.65,
+          279.15, 18.13, 272.8, 0, 262.81
+        ]
+      ],
+      "num_keypoints": 1,
+      "area": 1037.7819,
+      "iscrowd": 0,
+      "keypoints": [
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 9, 277, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0
+      ],
+      "image_id": 397133,
+      "bbox": [0, 262.81, 62.16, 36.77],
+      "category_id": 1,
+      "id": 1218137
+    }
+  ],
+  "categories": [
+    {
+      "supercategory": "person",
+      "id": 1,
+      "name": "person",
+      "keypoints": [
+        "nose",
+        "left_eye",
+        "right_eye",
+        "left_ear",
+        "right_ear",
+        "left_shoulder",
+        "right_shoulder",
+        "left_elbow",
+        "right_elbow",
+        "left_wrist",
+        "right_wrist",
+        "left_hip",
+        "right_hip",
+        "left_knee",
+        "right_knee",
+        "left_ankle",
+        "right_ankle"
+      ],
+      "skeleton": [
+        [16, 14],
+        [14, 12],
+        [17, 15],
+        [15, 13],
+        [12, 13],
+        [6, 12],
+        [7, 13],
+        [6, 7],
+        [6, 8],
+        [7, 9],
+        [8, 10],
+        [9, 11],
+        [2, 3],
+        [1, 2],
+        [1, 3],
+        [2, 4],
+        [3, 5],
+        [4, 6],
+        [5, 7]
+      ]
+    }
+  ]
+}

--- a/airo-dataset-tools/test/test_segmentation_mask.py
+++ b/airo-dataset-tools/test/test_segmentation_mask.py
@@ -24,6 +24,21 @@ def test_encoded_rle_creation():
     assert np.array_equal(loaded_segmentation_mask.bitmap, mask)
 
 
+def test_polygon_creation():
+    mask = np.zeros((10, 10))
+    mask[1, 1:3] = 1
+    mask[2, 1:3] = 1
+    segmentation_mask = BinarySegmentationMask(mask)
+
+    polygon = segmentation_mask.as_polygon
+    assert isinstance(polygon, list)
+    assert isinstance(polygon[0], list)
+    assert isinstance(polygon[0][0], float)
+    assert len(polygon) == 1
+    assert len(polygon[0]) == 8
+    assert polygon[0] == [1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 1.0]
+
+
 def test_coco_segmentation_loading():
     test_dir = os.path.dirname(os.path.realpath(__file__))
     annotations = os.path.join(test_dir, "test_data/instances_val2017_small.json")

--- a/mypy.ini
+++ b/mypy.ini
@@ -22,7 +22,7 @@ warn_redundant_casts = True
 # warn about # type: ignore that are not required
 warn_unused_ignores = True
 # do not allow the use of untyped import classes for typing
-disallow_any_unimported = False
+disallow_any_unimported = True
 # have to type optional arguments explicitly
 no_implicit_optional = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -22,7 +22,7 @@ warn_redundant_casts = True
 # warn about # type: ignore that are not required
 warn_unused_ignores = True
 # do not allow the use of untyped import classes for typing
-disallow_any_unimported = True
+disallow_any_unimported = False
 # have to type optional arguments explicitly
 no_implicit_optional = True
 
@@ -61,4 +61,6 @@ ignore_missing_imports=True
 [mypy-xmltodict.*]
 ignore_missing_imports=True
 [mypy-tqdm.*]
+ignore_missing_imports=True
+[mypy-albumentations.*]
 ignore_missing_imports=True


### PR DESCRIPTION
- function apply arbitrary albumentations transforms onto a coco dataset and its annotations
- expose resizing (most common transform) to CLI
- change defaults of bbox/seg masks to None in Coco Parser to avoid issues with fiftyone 