### PR TITLE
Changes for Zed SDK 4.0

### DIFF
--- a/airo-camera-toolkit/airo_camera_toolkit/cameras/zed2i.py
+++ b/airo-camera-toolkit/airo_camera_toolkit/cameras/zed2i.py
@@ -103,7 +103,8 @@ class Zed2i(StereoRGBDCamera):
 
         # TODO: create a configuration class for the runtime parameters
         self.runtime_params = sl.RuntimeParameters()
-        self.runtime_params.sensing_mode = sl.SENSING_MODE.STANDARD  # standard > fill for accuracy. See docs.
+        # Enabling fill mode changed for SDK 4.0: https://www.stereolabs.com/developers/release/4.0/migration-guide/
+        self.runtime_params.enable_fill_mode = False  # standard > fill for accuracy. See docs.
         self.runtime_params.texture_confidence_threshold = 100
         self.runtime_params.confidence_threshold = 100
         self.depth_enabled = True
@@ -148,10 +149,9 @@ class Zed2i(StereoRGBDCamera):
     def pose_of_right_view_in_left_view(self) -> HomogeneousMatrixType:
         # get the 'rectified' pose of the right view wrt to the left view
         # should be approx a translation along the x-axis of 120mm (Zed2i camera), expressed in the unit of the coordinates, which we set to meters.
-        # https://www.stereolabs.com/docs/api/python/classpyzed_1_1sl_1_1CalibrationParameters.html#a99ec1eeeb66c781c27b574fdc36881d2
-        matrix = np.eye(4)
-        matrix[:3, 3] = self.camera.get_camera_information().camera_configuration.calibration_parameters.T
-        return matrix
+        # https://www.stereolabs.com/docs/api/python/classpyzed_1_1sl_1_1CalibrationParameters.html
+        # Note: the CalibrationParameters class changed for the SDK 4.0, the old .T attribute we used was removed.
+        return self.camera.get_camera_information().camera_configuration.calibration_parameters.stereo_transform.m
 
     @property
     def depth_enabled(self) -> bool:


### PR DESCRIPTION
To investigate the flickering/tearing artifacts of one of our ZED2i camera's I updated the ZED SDK on the Gorilla workstation to 4.0. This did not solve the issue, however I guess we should update anyways.

The ZED SDK 4.0 has a few breaking changes, summarized (partially) in this [migration guide](https://www.stereolabs.com/developers/release/4.0/migration-guide/). This PR changes the `Zed2i` class in two places to fix the crashes when running the `zed2i.py` script.

Note that after this PR lands, instantiating `Zed2i` objects will fail with SDK versions <4.0. Should we add a check for this and warn users?