### PR TITLE
Bugfix: `orientation_as_axis_angle` dtype is not always float

### DIFF
--- a/airo-spatial-algebra/airo_spatial_algebra/se3.py
+++ b/airo-spatial-algebra/airo_spatial_algebra/se3.py
@@ -118,7 +118,6 @@ class SE3Container:
     @property
     def orientation_as_rotation_vector(self) -> Vector3DType:
         axis, angle = self.orientation_as_axis_angle
-
         if axis is None:
             return np.zeros(3)
         return angle * axis

--- a/airo-spatial-algebra/airo_spatial_algebra/se3.py
+++ b/airo-spatial-algebra/airo_spatial_algebra/se3.py
@@ -113,11 +113,12 @@ class SE3Container:
     @property
     def orientation_as_axis_angle(self) -> AxisAngleType:
         angle, axis = self.se3.angvec()
-        return axis, angle
+        return axis.astype(np.float64), float(angle)
 
     @property
     def orientation_as_rotation_vector(self) -> Vector3DType:
         axis, angle = self.orientation_as_axis_angle
+
         if axis is None:
             return np.zeros(3)
         return angle * axis

--- a/airo-spatial-algebra/test/test_se3_container.py
+++ b/airo-spatial-algebra/test/test_se3_container.py
@@ -100,3 +100,11 @@ def test_quaternion_scalar_conversion():
         quat,
         SE3Container.scalar_first_quaternion_to_scalar_last(SE3Container.scalar_last_quaternion_to_scalar_first(quat)),
     ).all()
+
+
+def test_axis_angle_dtypes():
+    se3 = SE3Container.from_homogeneous_matrix(np.identity(4))
+    axis, angle = se3.orientation_as_axis_angle
+    assert isinstance(angle, float)
+    assert isinstance(axis, np.ndarray)
+    assert axis.dtype == np.float64


### PR DESCRIPTION
The expected (and promised dtype) of `orientation_as_axis_angle` is `float`. However it was `int` for the identity pose. This caused OpenCV to raise a datatype error when the `orientation_as_rotation_vector` was used for its functions that take an `rvec`.

This PR explicity casts the output of `se3.angvec()` to float, and adds a test case.