### PR TITLE
Add versioning

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,16 +1,28 @@
+# how to use this?
+
+# for releasing new version:
+# bump-my-version bump micro <--no-tag> <--verbose> <-n>
+
+# for manually setting the version:
+# bump-my-version bump --new-version 2024.1.0
+
+# for marking dev build:
+# export SHORT_COMMIT_SHA=$(git rev-parse --short HEAD)
+# bump-my-version bump dev
+
 [tool.bumpversion]
 current_version = "0.0.1" # this is the single source of truth for the version
 
 # do not create tags or commits by default
 commit = false
-tag = false
+tag = true
 # allow to bump version even if there are uncommitted changes
 allow_dirty = true
 
 
 # parser
 # either YYYY.MM.MICRO or YYYY.MM.MICRO-build.date.COMMIT_SHA
-parse = "(?P<year>\\d+)\\.(?P<month>\\d+)\\.(?P<micro>\\d+)(?:\\-(?P<dev>release|build)\\.[0-9a-zA-Z-]+)?"
+parse = "(?P<year>[0-9]+)\\.(?P<month>[0-9]+)\\.(?P<micro>[0-9]+)(?:\\-(?P<dev>release|build)\\.[0-9a-zA-Z-]+)?"
 
 
 serialize = [
@@ -25,5 +37,11 @@ serialize = [
 # only build will appear in output if necessary
 values = ["release", "build"]
 
+[[tool.bumpversion.files]]
+glob = "**/setup.py"
 
+[[tool.bumpversion.files]]
+filename = "CHANGELOG.md"
+search = "Unreleased"
 
+#TODO: might want to auto-update internal dependencies!

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "2.6.0.build.None"
+current_version = "2.7.0"
 commit = false
 tag = false
 allow_dirty = true

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,31 +1,16 @@
 [tool.bumpversion]
-current_version = "0.0.1"
+current_version = "2.6.0.build.None"
 commit = false
 tag = false
 allow_dirty = true
-parse = """
-(?x)
-    (?P<year>[0-9]+)
-    \\.(?P<month>[0-9]+)
-    \\.(?P<id>[0-9]+)
-    (?:
-    \\-(?P<dev>build)
-    \\.(?P<build_id>[0-9]+)
-    \\.(?P<commit_sha>[a-f0-9]+)
-    )
-
-    ?
-
-"""
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:\\.(?P<dev>release|build)\\.[0-9a-zA-Z-]+)?"
 serialize = [
-    "{year}.{month}.{id}-{dev}.{build_id}.sha{commit_sha}",
-    "{year}.{month}.{id}",
-
+    "{major}.{minor}.{patch}.{dev}.{commit_sha}",
+    "{major}.{minor}.{patch}"
 ]
 
 
-[[tool.bumpversion.files]]
-glob = "*/setup.py"
-
+[tool.bumpversion.parts.dev]
+values = ["release", "build"]
 
 

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,0 +1,21 @@
+[tool.bumpversion]
+current_version = "2023.0.1-dev.1"
+commit = false
+tag = false
+allow_dirty = true
+parse = """
+(?x)
+    (?P<year>[0-9]+)
+    \\.(?P<month>[0-9]+)
+    \\.(?P<id>[0-9]+)
+    ?
+
+"""
+serialize = [
+    "{year}.{month}.{id}"
+]
+
+
+[[tool.bumpversion.files]]
+glob = "*/setup.py"
+

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "2023.0.1-dev.1"
+current_version = "0.0.1"
 commit = false
 tag = false
 allow_dirty = true
@@ -8,14 +8,24 @@ parse = """
     (?P<year>[0-9]+)
     \\.(?P<month>[0-9]+)
     \\.(?P<id>[0-9]+)
+    (?:
+    \\-(?P<dev>build)
+    \\.(?P<build_id>[0-9]+)
+    \\.(?P<commit_sha>[a-f0-9]+)
+    )
+
     ?
 
 """
 serialize = [
-    "{year}.{month}.{id}"
+    "{year}.{month}.{id}-{dev}.{build_id}.sha{commit_sha}",
+    "{year}.{month}.{id}",
+
 ]
 
 
 [[tool.bumpversion.files]]
 glob = "*/setup.py"
+
+
 

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -26,7 +26,7 @@ parse = "(?P<year>[0-9]+)\\.(?P<month>[0-9]+)\\.(?P<micro>[0-9]+)(?:\\-(?P<dev>r
 
 
 serialize = [
-    "{year}.{month}.{micro}-{dev}.{now:%D-%H-%M}.{$SHORT_COMMIT_SHA}", # the serializer for dev builds; commit SHA is env variable;
+    "{year}.{month}.{micro}-{dev}.{now:%Y/%m/%d-%H-%M}.{$SHORT_COMMIT_SHA}", # the serializer for dev builds; commit SHA is env variable;
     # note that builds cannot be incremented!
     # this is purely for covenience of building intermediate versions without actually bumping the version in the codebase
     "{year}.{month}.{micro}" # serializer for actual releases

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,17 +1,24 @@
 [tool.bumpversion]
-current_version = "0.0.3"
+current_version = "0.0.1" # this is the single source of truth for the version
 
 # do not create tags or commits by default
 commit = false
 tag = false
+# allow to bump version even if there are uncommitted changes
 allow_dirty = true
-# parser
-parse = "(?P<year>\\d+)\\.(?P<month>\\d+)\\.(?P<id>\\d+)\\-(?P<dev>release|build)\\.[0-9a-zA-Z-]+?"
-serialize = [
-    "{year}.{month}.{id}-{dev}.{$SHORT_COMMIT_SHA}", # commit SHA is env variable
-    "{year}.{month}.{id}"
-]
 
+
+# parser
+# either YYYY.MM.MICRO or YYYY.MM.MICRO-build.date.COMMIT_SHA
+parse = "(?P<year>\\d+)\\.(?P<month>\\d+)\\.(?P<micro>\\d+)(?:\\-(?P<dev>release|build)\\.[0-9a-zA-Z-]+)?"
+
+
+serialize = [
+    "{year}.{month}.{micro}-{dev}.{now:%D-%H-%M}.{$SHORT_COMMIT_SHA}", # the serializer for dev builds; commit SHA is env variable;
+    # note that builds cannot be incremented!
+    # this is purely for covenience of building intermediate versions without actually bumping the version in the codebase
+    "{year}.{month}.{micro}" # serializer for actual releases
+]
 
 [tool.bumpversion.parts.dev]
 # first value is optional and hence omitted from version output

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -11,7 +11,7 @@
 # bump-my-version bump dev
 
 [tool.bumpversion]
-current_version = "0.0.1" # this is the single source of truth for the version
+current_version = "2024.1.0" # this is the single source of truth for the version
 
 # do not create tags or commits by default
 commit = false

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,16 +1,22 @@
 [tool.bumpversion]
-current_version = "2.7.0"
+current_version = "0.0.3"
+
+# do not create tags or commits by default
 commit = false
 tag = false
 allow_dirty = true
-parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:\\.(?P<dev>release|build)\\.[0-9a-zA-Z-]+)?"
+# parser
+parse = "(?P<year>\\d+)\\.(?P<month>\\d+)\\.(?P<id>\\d+)\\-(?P<dev>release|build)\\.[0-9a-zA-Z-]+?"
 serialize = [
-    "{major}.{minor}.{patch}.{dev}.{commit_sha}",
-    "{major}.{minor}.{patch}"
+    "{year}.{month}.{id}-{dev}.{$SHORT_COMMIT_SHA}", # commit SHA is env variable
+    "{year}.{month}.{id}"
 ]
 
 
 [tool.bumpversion.parts.dev]
+# first value is optional and hence omitted from version output
+# only build will appear in output if necessary
 values = ["release", "build"]
+
 
 

--- a/.github/.pull_request_template.md
+++ b/.github/.pull_request_template.md
@@ -1,0 +1,6 @@
+## Describe your changes
+
+
+## Checklist
+- [ ] Have you modified the changelog?
+- [ ] If you made changes to the hardware interfaces, have you tested them using the manual tests?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,19 +3,18 @@
 All notable changes for the packages in the airo-mono repo are documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
-This project uses a custom versioning scheme with monthly releases, see [here](versioning.md)
+This project uses a [CalVer](https://calver.org/) versioning scheme with monthly releases, see [here](versioning.md)
 
 ## Unreleased
 
 ### Breaking changes
 
 ### Added
+- Calendar-based versioning scheme and introduction of accompanying changelog.
 
 ### Changed
 
 ### Fixed
 
 ### Removed
-
----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes for the packages in the airo-mono repo are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project uses a [CalVer](https://calver.org/) versioning scheme with monthly releases, see [here](versioning.md)
 
-## Unreleased
+## 2024.1.0
 
 ### Breaking changes
 

--- a/airo-camera-toolkit/setup.py
+++ b/airo-camera-toolkit/setup.py
@@ -5,7 +5,7 @@ import setuptools
 root_folder = pathlib.Path(__file__).parents[1]
 setuptools.setup(
     name="airo_camera_toolkit",
-    version="0.0.1",
+    version="2024.1.0",
     description="Interfaces and common functionality to work with RGB(D) cameras for robotic manipulation at the Ghent University AI and Robotics Lab",
     author="Thomas Lips",
     author_email="thomas.lips@ugent.be",

--- a/airo-dataset-tools/setup.py
+++ b/airo-dataset-tools/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages
 root_folder = pathlib.Path(__file__).parents[1]
 setuptools.setup(
     name="airo-dataset-tools",
-    version="0.0.1",
+    version="2024.1.0",
     author="Victor-Louis De Gusseme",
     author_email="victorlouisdg@gmail.com",
     description="TODO",

--- a/airo-robots/setup.py
+++ b/airo-robots/setup.py
@@ -5,7 +5,7 @@ import setuptools
 root_folder = pathlib.Path(__file__).parents[1]
 setuptools.setup(
     name="airo_robots",
-    version="0.0.1",
+    version="2024.1.0",
     description="Interfaces, hardware implementations of those interfaces and other functionalities to control robot manipulators and grippers at the Ghent University AI and Robotics Lab",
     author="Thomas Lips",
     author_email="thomas.lips@ugent.be",

--- a/airo-spatial-algebra/setup.py
+++ b/airo-spatial-algebra/setup.py
@@ -5,7 +5,7 @@ import setuptools
 root_folder = pathlib.Path(__file__).parents[1]
 setuptools.setup(
     name="airo_spatial_algebra",
-    version="0.0.1",
+    version="2024.1.0",
     description="code for working with SE3 poses,transforms,... for robotic manipulation at the Ghent University AI and Robotics Lab",
     author="Thomas Lips",
     author_email="thomas.lips@ugent.be",

--- a/airo-teleop/setup.py
+++ b/airo-teleop/setup.py
@@ -5,7 +5,7 @@ import setuptools
 root_folder = pathlib.Path(__file__).parents[1]
 setuptools.setup(
     name="airo_teleop",
-    version="0.0.1",
+    version="2024.1.0",
     description="teleoperation functionality for manually controlling manipulators and grippers using gaming controllers etc. at the Ghent University AI and Robotics Lab",
     author="Thomas Lips",
     author_email="thomas.lips@ugent.be",

--- a/airo-typing/setup.py
+++ b/airo-typing/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="airo_typing",
-    version="0.0.1",
+    version="2024.1.0",
     description="python type definitions for use in the python packages at the Ghent University AI and Robotics Lab",
     author="Thomas Lips",
     author_email="thomas.lips@ugent.be",

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,3 +4,5 @@ pytest
 pytest-xdist # multi-core
 pytest-cov # coverage
 nbmake # pytest notebook
+build  # build distributions
+bump-my-version # version bumping

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes for the packages in the airo-mono repo are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+This project uses a custom versioning scheme with monthly releases, see [here](versioning.md)
+
+## Unreleased
+
+### Breaking changes
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+
+---
+

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,7 +1,7 @@
 # Releasing
 
 
-To create a release manually there are two steps:
+To create a new release there are two steps:
 
 
 1. version bumping
@@ -11,17 +11,8 @@ To create a release manually there are two steps:
 
 ## Version bumping
 
-run following command:
-`bump-my-version bump --new-version <YYYY.MM.N>`
-
-Where YYYY.MM are the year and month of the date and N is the micro part used to discriminate between releases in the same month. N starts at 0.
-
-so for the initial release under this scheme on 8, Jan 2024 the following command was used: `bump-my-version bump --new-version 2024.1.0`
-
-You can use the `--verbose` flag for more output and `-n` to dry-run.
-
-
-Next to updating the version strings in all relevant files, this will also create a git tag to be associated with the release.
-
+see [versioning](./versioning.md)
 
 ## Creating distribution
+
+ TODO, not implemented yet.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,27 @@
+# Releasing
+
+
+To create a release manually there are two steps:
+
+
+1. version bumping
+2. create & publish distribution
+
+
+
+## Version bumping
+
+run following command:
+`bump-my-version bump --new-version <YYYY.MM.N>`
+
+Where YYYY.MM are the year and month of the date and N is the micro part used to discriminate between releases in the same month. N starts at 0.
+
+so for the initial release under this scheme on 8, Jan 2024 the following command was used: `bump-my-version bump --new-version 2024.1.0`
+
+You can use the `--verbose` flag for more output and `-n` to dry-run.
+
+
+Next to updating the version strings in all relevant files, this will also create a git tag to be associated with the release.
+
+
+## Creating distribution

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -4,6 +4,7 @@
 The airo-mono repo uses a single global version using a `YYYY.MM.N version scheme`.
 Compatability between the packages is only guaranteed between identical versions, so you should use the same version of all packages.
 
+The single point of truth for the version is in the `.bumpversion.toml` file.
 
 ## Scheme
 We use a [Calender Version](https://calver.org/) scheme as follows:
@@ -12,9 +13,9 @@ We use a [Calender Version](https://calver.org/) scheme as follows:
 YYYY.MM.N
 ```
 
-where N is the MICRO part, used to distinguish between multiple releases in the same month. No semantic meaning can be attached to the versions and breaking changes might occur in each release for now.
+where YYYY.MM is the year and month in which the release is made and N is the MICRO part used to distinguish between multiple releases in the same month. No semantic meaning can be attached to the micro parts and breaking changes might occur in each release for now.
 
-## Releasing strategy
+## Versioning strategy
 The main branch ('our trunk') will always live at last released version. All development builds will hence have the **previous** release as base.
 This is slightly counter-intuitive but actually common practice (e.g. [Twisted](https://github.com/twisted/twisted/tree/trunk)).
 
@@ -30,6 +31,7 @@ YYYY.MM.N-build.date.sha
 ```
 
 the regular version is the to-be-released version. The build date is added after the tag, as well as the SHA of the corresponding commit for ease of use.
+To create a development build, run `bump-my-version bump dev`. Note that this command is meant for CI builds and it is not possible to bump build versions.
 ## Rationale
 ### Why not semantic versioning?
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,42 @@
+# Versioning
+
+
+The airo-mono repo uses a single global version using a `YYYY.MM.N version scheme`.
+Compatability between the packages is only guaranteed between identical versions, so you should use the same version of all packages.
+
+
+## Scheme
+We use a [Calender Version](https://calver.org/) scheme as follows:
+
+```
+YYYY.MM.N
+```
+
+where N is the MICRO part, used to distinguish between multiple releases in the same month. No semantic meaning can be attached to the versions and breaking changes might occur in each release for now.
+
+## Releasing strategy
+The main branch ('our trunk') will always live at an unreleased version.
+When releasing a new version, it will be bumped immediately after the release.
+
+For info on how to create releases, see [releasing.md](releasing.md).
+
+
+## Development distributions/builds
+Development builds might be available and their versioning scheme is
+```
+YYYY.MM.N-build.date.sha
+```
+
+the regular version is the to-be-released version. The build date is added after the tag, as well as the SHA of the corresponding commit for ease of use.
+## Rationale
+### Why not semantic versioning?
+
+We don't want to create friction for making breaking changes for now.
+
+### Why a global version instead of independent versions for each package?
+
+Creates additional bookkeeping for adding compatibilities and breaks with the idea of 'version has unique commit/tag'.
+Gives limited advantages in return.
+
+Global version simply seems to be more in line with the 'mono-repo' approach.
+

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -13,25 +13,43 @@ We use a [Calender Version](https://calver.org/) scheme as follows:
 YYYY.MM.N
 ```
 
-where YYYY.MM is the year and month in which the release is made and N is the MICRO part used to distinguish between multiple releases in the same month. No semantic meaning can be attached to the micro parts and breaking changes might occur in each release for now.
+where YYYY.MM is the year and month in which the release is made and N is the MICRO part used to distinguish between multiple releases in the same month. No semantic meaning can be attached to the parts and breaking changes might occur in each release for now.
 
 ## Versioning strategy
 The main branch ('our trunk') will always live at last released version. All development builds will hence have the **previous** release as base.
 This is slightly counter-intuitive but actually common practice (e.g. [Twisted](https://github.com/twisted/twisted/tree/trunk)).
 
-When releasing a new version, the version on the main branch should hence be bumped before the release.
+## version bumping
 
-For info on how to create releases, see [releasing.md](releasing.md).
+To create a new version, you simply bump the version number as follows:
 
+- take the year and month of the current day, e.g. 2024/01
+- check the previous version (`.bumpversion.toml` file), if it was released in the same month, you bump the micro part. E.g. if the current version was 2024.1.2, the new version becomes 2024.1.3. If the latest version was from a previous month, you set the micro part to zero. e.g. if the current version was 2023.10.4, the new version is 2024.1.0.
+
+use the `bump-my-version` command to set the new version:
+
+run following command:
+`bump-my-version bump --new-version <YYYY.MM.N>`
+
+Where YYYY.MM are the year and month of the date and N is the micro part used to discriminate between releases in the same month. N starts at 0.
+
+so for the initial release under this scheme on 8, Jan 2024 the following command was used: `bump-my-version bump --new-version 2024.1.0`
+
+You can use the `--verbose` flag for more output and `-n` to dry-run.
+
+
+Next to updating the version strings in all relevant files, this will also create a git tag to be associated with the release.
 
 ## Development distributions/builds
-Development builds might be available and their versioning scheme is
+Development builds can be used to build the development trunk (main branch) and their versioning scheme is
 ```
 YYYY.MM.N-build.date.sha
 ```
 
-the regular version is the to-be-released version. The build date is added after the tag, as well as the SHA of the corresponding commit for ease of use.
+the regular version is the current version. The build date is added after the tag, as well as the SHA of the corresponding commit for ease of use.
 To create a development build, run `bump-my-version bump dev`. Note that this command is meant for CI builds and it is not possible to bump build versions.
+
+
 ## Rationale
 ### Why not semantic versioning?
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -15,8 +15,10 @@ YYYY.MM.N
 where N is the MICRO part, used to distinguish between multiple releases in the same month. No semantic meaning can be attached to the versions and breaking changes might occur in each release for now.
 
 ## Releasing strategy
-The main branch ('our trunk') will always live at an unreleased version.
-When releasing a new version, it will be bumped immediately after the release.
+The main branch ('our trunk') will always live at last released version. All development builds will hence have the **previous** release as base.
+This is slightly counter-intuitive but actually common practice (e.g. [Twisted](https://github.com/twisted/twisted/tree/trunk)).
+
+When releasing a new version, the version on the main branch should hence be bumped before the release.
 
 For info on how to create releases, see [releasing.md](releasing.md).
 


### PR DESCRIPTION
Introduces a global version for the mono repo packages using a calendar based versioning scheme:

```YYYY.MM.N```

 intermediate development builds use `YYYY.MM.N-build.current_date.commit_sha`, where the prefix is the latest release.



[bump-my-version](https://callowayproject.github.io/bump-my-version/index.html) is used to automate version bumping as much as possible.


---

Versioning benefits from a changelog, one was added inspired on [https://keepachangelog.com/en/1.1.0/](https://keepachangelog.com/en/1.1.0/)

--- 
an initial version `2024.1.0` was also added