### PR TITLE
Multiprocessing resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This project uses a [CalVer](https://calver.org/) versioning scheme with monthly
 - Fixed bug requiring unplug-and-plug of USB cable for Realsense: see issue #109.
 - Removed camera imports in `airo_camera_toolkit.cameras`: see issue #110.
 - Added `__init__.py` to `realsense` and `utils` in `airo_camera_toolkit.cameras`, fixing installs with pip and issue #113.
+- Fixed bug that returned a transposed resolution in `MultiprocessRGBReceiver`.
 
 ### Removed
 - `ColoredPointCloudType`

--- a/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/multiprocess_rgb_camera.py
+++ b/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/multiprocess_rgb_camera.py
@@ -251,7 +251,7 @@ class MultiprocessRGBReceiver(RGBCamera):
     def resolution(self) -> CameraResolutionType:
         """The resolution of the camera, in pixels."""
         shape_array = [int(x) for x in self.rgb_shape_shm_array[:2]]
-        return (shape_array[0], shape_array[1])
+        return (shape_array[1], shape_array[0])
 
     def _grab_images(self) -> None:
         while not self.get_current_timestamp() > self.previous_timestamp:


### PR DESCRIPTION
## Describe your changes

`MultiprocessRGBReceiver` returned the resolution as `(H, W)` instead of the expected `(W, H)`. The values have been swapped.