### PR TITLE
Initial path types

### DIFF
--- a/airo-typing/airo_typing/__init__.py
+++ b/airo-typing/airo_typing/__init__.py
@@ -79,24 +79,47 @@ JointConfigurationType = np.ndarray
 JointPathType = np.ndarray
 """ a (T, N) array of joint states (can be position/velocity/acceleration) that describe a path in joint space"""
 
+TimesType = np.ndarray
+""" a (T,) array of monotonically increasing times (float), corresponding to a path"""
+
+
+@dataclass
+class JointTrajectory:
+    positions: JointPathType
+    velocities: Optional[JointPathType] = None
+    accelerations: Optional[JointPathType] = None
+    efforts: Optional[JointPathType] = None
+    times: Optional[TimesType] = None  # time from start of trajectory | assumed 0->1 if None
+
+
+@dataclass
+class DualArmJointTrajectory:
+    positions_left: JointPathType
+    positions_right: JointPathType
+    velocities_left: Optional[JointPathType] = None
+    velocities_right: Optional[JointPathType] = None
+    accelerations_left: Optional[JointPathType] = None
+    accelerations_right: Optional[JointPathType] = None
+    efforts_left: Optional[JointPathType] = None
+    efforts_right: Optional[JointPathType] = None
+    times: Optional[TimesType] = None  # time from start of trajectory | assumed 0->1 if None
+
+
 PosePathType = np.ndarray
 """ a (T, 4, 4) list of homogeneous matrices that describe a path in cartesian space"""
 
-TimePathType = np.ndarray
-""" a (T,) array of monotonically increasing times (float), corresponding to a path"""
 
-#######################
-# Single-arm types #
-#######################
+@dataclass
+class PoseTrajectory:
+    poses: PosePathType
+    times: Optional[TimesType] = None
+
+
 ForwardKinematicsFunctionType = Callable[[JointConfigurationType], HomogeneousMatrixType]
 """ a function that computes the forward kinematics of a given joint configuration"""
 
 InverseKinematicsFunctionType = Callable[[HomogeneousMatrixType], List[JointConfigurationType]]
 """ a function that computes one or more inverse kinematics solutions of a given TCP pose"""
-
-#########################
-# Motion planning types #
-#########################
 
 JointConfigurationCheckerType = Callable[[JointConfigurationType], bool]
 """ a function that checks a certain condition on a joint configuration, e.g. collision checking"""

--- a/airo-typing/airo_typing/__init__.py
+++ b/airo-typing/airo_typing/__init__.py
@@ -113,8 +113,8 @@ PosePathType = np.ndarray
 
 @dataclass
 class PoseTrajectory:
+    times: TimesType
     poses: PosePathType
-    times: Optional[TimesType] = None
 
 
 ForwardKinematicsFunctionType = Callable[[JointConfigurationType], HomogeneousMatrixType]

--- a/airo-typing/airo_typing/__init__.py
+++ b/airo-typing/airo_typing/__init__.py
@@ -84,25 +84,27 @@ TimesType = np.ndarray
 
 
 @dataclass
-class JointTrajectory:
-    positions: JointPathType
+class JointPathContainer:
+    positions: Optional[JointPathType] = None
     velocities: Optional[JointPathType] = None
     accelerations: Optional[JointPathType] = None
     efforts: Optional[JointPathType] = None
-    times: Optional[TimesType] = None  # time from start of trajectory | assumed 0->1 if None
 
 
 @dataclass
-class DualArmJointTrajectory:
-    positions_left: JointPathType
-    positions_right: JointPathType
-    velocities_left: Optional[JointPathType] = None
-    velocities_right: Optional[JointPathType] = None
-    accelerations_left: Optional[JointPathType] = None
-    accelerations_right: Optional[JointPathType] = None
-    efforts_left: Optional[JointPathType] = None
-    efforts_right: Optional[JointPathType] = None
-    times: Optional[TimesType] = None  # time from start of trajectory | assumed 0->1 if None
+class SingleArmTrajectory:
+    path: JointPathContainer
+    gripper_path: Optional[JointPathContainer]
+    times: TimesType  # time (seconds) from start of trajectory
+
+
+@dataclass
+class DualArmTrajectory:
+    path_left: JointPathContainer
+    path_right: JointPathContainer
+    gripper_left: Optional[JointPathContainer]
+    gripper_right: Optional[JointPathContainer]
+    times: TimesType  # time (seconds) from start of trajectory
 
 
 PosePathType = np.ndarray

--- a/airo-typing/airo_typing/__init__.py
+++ b/airo-typing/airo_typing/__init__.py
@@ -94,7 +94,7 @@ class JointPathContainer:
 @dataclass
 class SingleArmTrajectory:
     path: JointPathContainer
-    gripper_path: Optional[JointPathContainer]
+    gripper_path: Optional[JointPathContainer] = None
     times: TimesType  # time (seconds) from start of trajectory
 
 
@@ -102,8 +102,8 @@ class SingleArmTrajectory:
 class DualArmTrajectory:
     path_left: JointPathContainer
     path_right: JointPathContainer
-    gripper_left: Optional[JointPathContainer]
-    gripper_right: Optional[JointPathContainer]
+    gripper_path_left: Optional[JointPathContainer] = None
+    gripper_path_right: Optional[JointPathContainer] = None
     times: TimesType  # time (seconds) from start of trajectory
 
 

--- a/airo-typing/airo_typing/__init__.py
+++ b/airo-typing/airo_typing/__init__.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, Optional, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -69,10 +69,66 @@ TwistType = np.ndarray
 shorthand notation is ^C T^B_A, where C is the frame the velocity is measured in, B is the frame the velocity is expressed in.
 """
 
-# manipulator types
+#####################
+# Manipulator types #
+#####################
 
 JointConfigurationType = np.ndarray
 """an (N,) numpy array that represents the joint angles for a robot"""
+
+#########################
+# Single-arm path types #
+#########################
+JointPathType = List[JointConfigurationType]
+""" a list of joint configurations that describe a path in joint space"""
+
+JointPathArrayType = np.ndarray
+""" a (N, DoFs) numpy array that represents a path in joint space"""
+
+PosePathType = List[HomogeneousMatrixType]
+""" a list of homogeneous matrices that describe a path in cartesian space"""
+
+PosePathArrayType = np.ndarray
+""" a (N, 4, 4) numpy array that represents a path in cartesian space"""
+
+TimePathType = List[float]
+""" a list of times that describe a path in time, must be monotonically increasing"""
+
+TimePathArrayType = np.ndarray
+""" a (N,) numpy array that represents a path in time, must be monotonically increasing"""
+
+#######################
+# Dual-arm path types #
+#######################
+DualJointConfigurationType = np.ndarray
+""" a (2 * DoFs,) numpy array, result of np.hstack((left_joints, right_joints))"""
+
+DualJointPathType = List[DualJointConfigurationType]
+""" a list of dual arm joint configurations that describe a path in joint space"""
+
+DualJointPathArrayType = np.ndarray
+""" a (N, 2 * DoFs) array, result of np.hstack((left_joint_path, right_joint_path))"""
+
+#######################
+# Single-arm types #
+#######################
+ForwardKinematicsType = Callable[[JointConfigurationType], HomogeneousMatrixType]
+""" a function that computes the forward kinematics of a given joint configuration"""
+
+InverseKinematicsType = Callable[[HomogeneousMatrixType], List[JointConfigurationType]]
+""" a function that computes one or more inverse kinematics solutions of a given TCP pose"""
+
+
+#########################
+# Motion planning types #
+#########################
+
+JointConfigurationCheckerType = Callable[[JointConfigurationType], bool]
+""" a function that checks a certain condition on a joint configuration, e.g. collision checking"""
+
+DualJointConfigurationCheckerType = Callable[[DualJointConfigurationType], bool]
+""" a function that checks a dual joint configuration, where the JointConfigurationType is the stacked version of the left and right joint configurations"""
+
 
 ######################
 # camera related types

--- a/airo-typing/airo_typing/__init__.py
+++ b/airo-typing/airo_typing/__init__.py
@@ -93,18 +93,18 @@ class JointPathContainer:
 
 @dataclass
 class SingleArmTrajectory:
+    times: TimesType  # time (seconds) from start of trajectory
     path: JointPathContainer
     gripper_path: Optional[JointPathContainer] = None
-    times: TimesType  # time (seconds) from start of trajectory
 
 
 @dataclass
 class DualArmTrajectory:
+    times: TimesType  # time (seconds) from start of trajectory
     path_left: JointPathContainer
     path_right: JointPathContainer
     gripper_path_left: Optional[JointPathContainer] = None
     gripper_path_right: Optional[JointPathContainer] = None
-    times: TimesType  # time (seconds) from start of trajectory
 
 
 PosePathType = np.ndarray

--- a/airo-typing/airo_typing/__init__.py
+++ b/airo-typing/airo_typing/__init__.py
@@ -76,48 +76,23 @@ shorthand notation is ^C T^B_A, where C is the frame the velocity is measured in
 JointConfigurationType = np.ndarray
 """an (N,) numpy array that represents the joint angles for a robot"""
 
-#########################
-# Single-arm path types #
-#########################
-JointPathType = List[JointConfigurationType]
-""" a list of joint configurations that describe a path in joint space"""
+JointPathType = np.ndarray
+""" a (T, N) array of joint states (can be position/velocity/acceleration) that describe a path in joint space"""
 
-JointPathArrayType = np.ndarray
-""" a (N, DoFs) numpy array that represents a path in joint space"""
+PosePathType = np.ndarray
+""" a (T, 4, 4) list of homogeneous matrices that describe a path in cartesian space"""
 
-PosePathType = List[HomogeneousMatrixType]
-""" a list of homogeneous matrices that describe a path in cartesian space"""
-
-PosePathArrayType = np.ndarray
-""" a (N, 4, 4) numpy array that represents a path in cartesian space"""
-
-TimePathType = List[float]
-""" a list of times that describe a path in time, must be monotonically increasing"""
-
-TimePathArrayType = np.ndarray
-""" a (N,) numpy array that represents a path in time, must be monotonically increasing"""
-
-#######################
-# Dual-arm path types #
-#######################
-DualJointConfigurationType = np.ndarray
-""" a (2 * DoFs,) numpy array, result of np.hstack((left_joints, right_joints))"""
-
-DualJointPathType = List[DualJointConfigurationType]
-""" a list of dual arm joint configurations that describe a path in joint space"""
-
-DualJointPathArrayType = np.ndarray
-""" a (N, 2 * DoFs) array, result of np.hstack((left_joint_path, right_joint_path))"""
+TimePathType = np.ndarray
+""" a (T,) array of monotonically increasing times (float), corresponding to a path"""
 
 #######################
 # Single-arm types #
 #######################
-ForwardKinematicsType = Callable[[JointConfigurationType], HomogeneousMatrixType]
+ForwardKinematicsFunctionType = Callable[[JointConfigurationType], HomogeneousMatrixType]
 """ a function that computes the forward kinematics of a given joint configuration"""
 
-InverseKinematicsType = Callable[[HomogeneousMatrixType], List[JointConfigurationType]]
+InverseKinematicsFunctionType = Callable[[HomogeneousMatrixType], List[JointConfigurationType]]
 """ a function that computes one or more inverse kinematics solutions of a given TCP pose"""
-
 
 #########################
 # Motion planning types #
@@ -125,10 +100,6 @@ InverseKinematicsType = Callable[[HomogeneousMatrixType], List[JointConfiguratio
 
 JointConfigurationCheckerType = Callable[[JointConfigurationType], bool]
 """ a function that checks a certain condition on a joint configuration, e.g. collision checking"""
-
-DualJointConfigurationCheckerType = Callable[[DualJointConfigurationType], bool]
-""" a function that checks a dual joint configuration, where the JointConfigurationType is the stacked version of the left and right joint configurations"""
-
 
 ######################
 # camera related types


### PR DESCRIPTION
## Describe your changes
This PR introduces types that are needed for motion planning.

As an initial suggestion I've decided to treat dual arm configurations as an array `np.hstack((joints_left, joints_right))`. The alternative is treating them as the tuple `(joints_left, joints_right)`. Both options have pros and cons we should consider.

Additionally, for the paths I've provided both list and array types. We should consider whether both are actually necessary.

### Considerations
* `DualJointConfigurationType` being the `hstack` or two `JointConfigurationType` is similar to how Drake combines all state of a plant. E.g. calling `sceneGraphCollisionChecker.CheckConfigCollisionFree` expects a (12, ) numpy array for my dual UR5e scenes. 
* Stacking might require code like this: `joints_left, joints_right = joints_dual[:6], joints_dual[6:] or np.split(joints_dual, 2)`. I'm not sure if this or better or worse than unpacking a tuple `joints_left, joints_right = joints_dual`. The tuple approach could support two arms with different #DoFs.
* The list/array types are somewhat redundant, but some path operations require arrays, such as `np.diff(path_array, axis=0)`.
* How we will handle additional DoFs, such as trajectories for gripper position?

## Checklist
- [ ] Have you modified the changelog?
