### PR TITLE
Revert Python to version 3.10 #121

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.9,'3.10','3.11']
+        python-version: [ 3.9,'3.10']
         #os: [ubuntu-latest, windows-latest, macos-latest] # avoid this cost untill it becomes necessary..
         package: [airo-typing,airo-spatial-algebra, airo-camera-toolkit, airo-robots, airo-teleop, airo-dataset-tools] #TODO: autodiscover?
     steps:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.9,'3.10']
+        python-version: [ 3.9,'3.10','3.11']
         #os: [ubuntu-latest, windows-latest, macos-latest] # avoid this cost untill it becomes necessary..
         package: [airo-typing,airo-spatial-algebra, airo-camera-toolkit, airo-robots, airo-teleop, airo-dataset-tools] #TODO: autodiscover?
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ This project uses a [CalVer](https://calver.org/) versioning scheme with monthly
 
 
 ### Changed
-- Dropped support for python 3.8 and added 3.10 to the testing matrix [#103](https://github.com/airo-ugent/airo-mono/issues/103).
+- Dropped support for python 3.8 and added 3.11 to the testing matrix [#103](https://github.com/airo-ugent/airo-mono/issues/103).
 - Set python version to 3.10 because of an issue with the `ur_rtde` wheels [#121](https://github.com/airo-ugent/airo-mono/issues/121). Updated README.md to reflect this change.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ This project uses a [CalVer](https://calver.org/) versioning scheme with monthly
 
 
 ### Changed
-- dropped support for python 3.8 and added 3.11 to the testing matrix [#103](https://github.com/airo-ugent/airo-mono/issues/103)
+- Dropped support for python 3.8 and added 3.10 to the testing matrix [#103](https://github.com/airo-ugent/airo-mono/issues/103).
+- Set python version to 3.10 because of an issue with the `ur_rtde` wheels [#121](https://github.com/airo-ugent/airo-mono/issues/121). Updated README.md to reflect this change.
 
 ### Fixed
 - Fixed bug in `get_colored_point_cloud()` that removed some points see issue #25.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ we use github actions to do the following checks on each PR, push to master (and
 
 The tests are executed for each package in isolation using [github actions Matrices](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs), which means that only that package and its dependencies are installed in an environment to make sure each package correctly declares its dependencies. The downside is that this has some overhead in creating the environments, so we should probably look into caching them once the runtime becomes longer.
 
-We test on python 3.8 (default on ubuntu 20.04), 3.9 and 3.10 (default on Ubuntu 22.04). It is important to test these versions explicitly, e.g. typing with `list` instead of `typing.List` is not allowed in 3.8, but it is in >=3.9.
+We test on python 3.9 and 3.10 (default on Ubuntu 22.04). It is important to test these versions explicitly, e.g. typing with `list` instead of `typing.List` is not allowed in 3.8, but it is in >=3.9.
 
 ### Management of (local) dependencies
 

--- a/README.md
+++ b/README.md
@@ -112,8 +112,6 @@ we use github actions to do the following checks on each PR, push to master (and
 
 The tests are executed for each package in isolation using [github actions Matrices](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs), which means that only that package and its dependencies are installed in an environment to make sure each package correctly declares its dependencies. The downside is that this has some overhead in creating the environments, so we should probably look into caching them once the runtime becomes longer.
 
-We test on python 3.9 and 3.10 (default on Ubuntu 22.04). It is important to test these versions explicitly, e.g. typing with `list` instead of `typing.List` is not allowed in 3.8, but it is in >=3.9.
-
 ### Management of (local) dependencies
 
 An issue with using a monorepo is that you want to have packages declare their local dependencies as well. But before you publish your packages or if you want to test unreleased code (as usually), this creates an issue: where should pip find these local package? Though there exist more advanced package managers such as Poetry, ([more background on package and dependency management in python](https://ealizadeh.com/blog/guide-to-python-env-pkg-dependency-using-conda-poetry/)

--- a/environment.yaml
+++ b/environment.yaml
@@ -2,7 +2,7 @@ name: airo-mono
 channels:
   - conda-forge
 dependencies:
-  - python=3.11
+  - python=3.10
   - pip
   - pip:
     - -e airo-typing/


### PR DESCRIPTION
## Describe your changes

See #121 

I think I got all instances where 3.11 was explicitly referenced, @tlpss does this look good?

## Checklist
- [x] Have you modified the changelog?

