### PR TITLE
Add ultra depth mode and fix performance depth mode in Zed2i

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,10 @@ This project uses a [CalVer](https://calver.org/) versioning scheme with monthly
 ### Added
 - `PointCloud` dataclass as the main data structure for point clouds in airo-mono
 - Notebooks to get started with point clouds, checking performance and logging to rerun
-- Functions to crop point clouds and filter points with a mask (e.g. low-confidence points))
+- Functions to crop point clouds and filter points with a mask (e.g. low-confidence points)
 - Functions to convert from our numpy-based dataclass to and from open3d point clouds
 - `BoundingBox3DType`
+- `Zed2i.ULTRA_DEPTH_MODE` to enable the ultra depth setting for the Zed2i cameras
 
 
 
@@ -32,6 +33,7 @@ This project uses a [CalVer](https://calver.org/) versioning scheme with monthly
 - Removed camera imports in `airo_camera_toolkit.cameras`: see issue #110.
 - Added `__init__.py` to `realsense` and `utils` in `airo_camera_toolkit.cameras`, fixing installs with pip and issue #113.
 - Fixed bug that returned a transposed resolution in `MultiprocessRGBReceiver`.
+- Using `Zed2i.PERFORMANCE_DEPTH_MODE` will now correctly use the performance mode instead of the quality mode.
 
 ### Removed
 - `ColoredPointCloudType`

--- a/airo-camera-toolkit/airo_camera_toolkit/cameras/zed/zed2i.py
+++ b/airo-camera-toolkit/airo_camera_toolkit/cameras/zed/zed2i.py
@@ -57,9 +57,10 @@ class Zed2i(StereoRGBDCamera):
     # no depth mode, higher troughput of the RGB images as the GPU has to do less work
     # can also turn depth off in the runtime params, which is recommended as it allows for switching at runtime.
     NONE_DEPTH_MODE = sl.DEPTH_MODE.NONE
-    PERFORMANCE_DEPTH_MODE = sl.DEPTH_MODE.QUALITY
+    PERFORMANCE_DEPTH_MODE = sl.DEPTH_MODE.PERFORMANCE
     QUALITY_DEPTH_MODE = sl.DEPTH_MODE.QUALITY
-    DEPTH_MODES = (NEURAL_DEPTH_MODE, NONE_DEPTH_MODE, PERFORMANCE_DEPTH_MODE, QUALITY_DEPTH_MODE)
+    ULTRA_DEPTH_MODE = sl.DEPTH_MODE.ULTRA
+    DEPTH_MODES = (NEURAL_DEPTH_MODE, NONE_DEPTH_MODE, PERFORMANCE_DEPTH_MODE, QUALITY_DEPTH_MODE, ULTRA_DEPTH_MODE)
 
     # for info on image resolution, pixel sizes, fov..., see:
     # https://support.stereolabs.com/hc/en-us/articles/360007395634-What-is-the-camera-focal-length-and-field-of-view-


### PR DESCRIPTION
## Describe your changes

- `PERFORMANCE_DEPTH_MODE = sl.DEPTH_MODE.PERFORMANCE` instead of `PERFORMANCE_DEPTH_MODE = sl.DEPTH_MODE.QUALITY` in the `Zed2i` class (I assume this was a mistake)
- Added `ULTRA_DEPTH_MODE = sl.DEPTH_MODE.ULTRA` in `Zed2i` class

## Checklist
- [x] Have you modified the changelog?
- [x] If you made changes to the hardware interfaces, have you tested them using the manual tests?
