### PR TITLE
Shared memory improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ This project uses a [CalVer](https://calver.org/) versioning scheme with monthly
 - Added `__init__.py` to `realsense` and `utils` in `airo_camera_toolkit.cameras`, fixing installs with pip and issue #113.
 - Fixed bug that returned a transposed resolution in `MultiprocessRGBReceiver`.
 - Using `Zed2i.PERFORMANCE_DEPTH_MODE` will now correctly use the performance mode instead of the quality mode.
+- Shared memory files that were not properly cleaned up are now unlinked and then recreated.
+- The wait interval for shared memory files has been reduced to .5 seconds (from 5), to speed up application start times.
 
 ### Removed
 - `ColoredPointCloudType`

--- a/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/multiprocess_rgb_camera.py
+++ b/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/multiprocess_rgb_camera.py
@@ -9,6 +9,7 @@ import numpy as np
 from airo_camera_toolkit.interfaces import RGBCamera
 from airo_camera_toolkit.utils.image_converter import ImageConverter
 from airo_typing import CameraIntrinsicsMatrixType, CameraResolutionType, NumpyFloatImageType, NumpyIntImageType
+from loguru import logger
 
 _RGB_SHM_NAME = "rgb"
 _RGB_SHAPE_SHM_NAME = "rgb_shape"
@@ -28,7 +29,10 @@ def shared_memory_block_like(array: np.ndarray, name: str) -> Tuple[shared_memor
     Returns:
         The created shared memory block and a new array that is backed by the shared memory block.
     """
-    shm = shared_memory.SharedMemory(create=True, size=array.nbytes, name=name)
+    try:
+        shm = shared_memory.SharedMemory(create=True, size=array.nbytes, name=name)
+    except FileExistsError:
+        logger.warning(f"Shared memory file {name} exists. Will try to re-use")
     shm_array: np.ndarray = np.ndarray(array.shape, dtype=array.dtype, buffer=shm.buf)
     shm_array[:] = array[:]
     return shm, shm_array

--- a/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/multiprocess_rgb_camera.py
+++ b/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/multiprocess_rgb_camera.py
@@ -213,8 +213,8 @@ class MultiprocessRGBReceiver(RGBCamera):
                 is_shm_found = True
                 break
             except FileNotFoundError:
-                print(
-                    f'INFO: SharedMemory namespace "{self._shared_memory_namespace}" not found yet, retrying in .5 seconds.'
+                logger.debug(
+                    f'SharedMemory namespace "{self._shared_memory_namespace}" not found yet, retrying in .5 seconds.'
                 )
                 time.sleep(0.5)
 

--- a/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/multiprocess_rgb_camera.py
+++ b/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/multiprocess_rgb_camera.py
@@ -214,9 +214,9 @@ class MultiprocessRGBReceiver(RGBCamera):
                 break
             except FileNotFoundError:
                 print(
-                    f'INFO: SharedMemory namespace "{self._shared_memory_namespace}" not found yet, retrying in 5 seconds.'
+                    f'INFO: SharedMemory namespace "{self._shared_memory_namespace}" not found yet, retrying in .5 seconds.'
                 )
-                time.sleep(5)
+                time.sleep(0.5)
 
         if not is_shm_found:
             raise FileNotFoundError("Shared memory not found.")

--- a/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/multiprocess_rgb_camera.py
+++ b/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/multiprocess_rgb_camera.py
@@ -32,7 +32,13 @@ def shared_memory_block_like(array: np.ndarray, name: str) -> Tuple[shared_memor
     try:
         shm = shared_memory.SharedMemory(create=True, size=array.nbytes, name=name)
     except FileExistsError:
-        logger.warning(f"Shared memory file {name} exists. Will try to re-use")
+        logger.warning(f"Shared memory file {name} exists. Will unlink and re-create it.")
+
+        shm_old = shared_memory.SharedMemory(create=False, size=array.nbytes, name=name)
+        shm_old.unlink()
+
+        shm = shared_memory.SharedMemory(create=True, size=array.nbytes, name=name)
+
     shm_array: np.ndarray = np.ndarray(array.shape, dtype=array.dtype, buffer=shm.buf)
     shm_array[:] = array[:]
     return shm, shm_array

--- a/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/multiprocess_rgbd_camera.py
+++ b/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/multiprocess_rgbd_camera.py
@@ -159,6 +159,8 @@ class MultiprocessRGBDReceiver(MultiprocessRGBReceiver, RGBDCamera):
 
     def _close_shared_memory(self) -> None:
         """Closing shared memory signal that"""
+        super()._close_shared_memory()
+
         self.depth_shm.close()
         self.depth_image_shm.close()
 

--- a/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/multiprocess_rgbd_camera.py
+++ b/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/multiprocess_rgbd_camera.py
@@ -121,8 +121,8 @@ class MultiprocessRGBDReceiver(MultiprocessRGBReceiver, RGBDCamera):
                 is_shm_found = True
                 break
             except FileNotFoundError:
-                print(
-                    f'INFO: SharedMemory namespace "{self._shared_memory_namespace}" (RGBD) not found yet, retrying in .5 seconds.'
+                logger.debug(
+                    f'SharedMemory namespace "{self._shared_memory_namespace}" not found yet, retrying in .5 seconds.'
                 )
                 time.sleep(0.5)
 

--- a/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/multiprocess_rgbd_camera.py
+++ b/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/multiprocess_rgbd_camera.py
@@ -122,9 +122,9 @@ class MultiprocessRGBDReceiver(MultiprocessRGBReceiver, RGBDCamera):
                 break
             except FileNotFoundError:
                 print(
-                    f'INFO: SharedMemory namespace "{self._shared_memory_namespace}" (RGBD) not found yet, retrying in 5 seconds.'
+                    f'INFO: SharedMemory namespace "{self._shared_memory_namespace}" (RGBD) not found yet, retrying in .5 seconds.'
                 )
-                time.sleep(5)
+                time.sleep(0.5)
 
         if not is_shm_found:
             raise FileNotFoundError("Shared memory not found.")

--- a/airo-camera-toolkit/airo_camera_toolkit/cameras/realsense/realsense.py
+++ b/airo-camera-toolkit/airo_camera_toolkit/cameras/realsense/realsense.py
@@ -60,10 +60,10 @@ class Realsense(RGBDCamera):
             config.enable_stream(rs.stream.depth, depth_resolution[0], depth_resolution[1], rs.format.z16, fps)
 
         # Avoid having to reconnect the USB cable, see https://github.com/IntelRealSense/librealsense/issues/6628#issuecomment-646558144
-        # ctx = rs.context()
-        # devices = ctx.query_devices()
-        # for dev in devices:
-        #     dev.hardware_reset()
+        ctx = rs.context()
+        devices = ctx.query_devices()
+        for dev in devices:
+            dev.hardware_reset()
 
         self.pipeline = rs.pipeline()
 

--- a/airo-camera-toolkit/airo_camera_toolkit/cameras/realsense/realsense.py
+++ b/airo-camera-toolkit/airo_camera_toolkit/cameras/realsense/realsense.py
@@ -60,10 +60,10 @@ class Realsense(RGBDCamera):
             config.enable_stream(rs.stream.depth, depth_resolution[0], depth_resolution[1], rs.format.z16, fps)
 
         # Avoid having to reconnect the USB cable, see https://github.com/IntelRealSense/librealsense/issues/6628#issuecomment-646558144
-        ctx = rs.context()
-        devices = ctx.query_devices()
-        for dev in devices:
-            dev.hardware_reset()
+        # ctx = rs.context()
+        # devices = ctx.query_devices()
+        # for dev in devices:
+        #     dev.hardware_reset()
 
         self.pipeline = rs.pipeline()
 


### PR DESCRIPTION
Closes #98 

## Describe your changes

- When a shared memory file exists (it was not properly cleaned up on a previous run), unlink it and recreate it.
- When a shared memory file does not yet exist and a subscriber is waiting for it, make the wait shorter (0.5 seconds instead of 5 seconds).
- Change the print statement for this into a logging statement

## Checklist
- [x] Have you modified the changelog?
- [x] If you made changes to the hardware interfaces, have you tested them using the manual tests?
