### PR TITLE
Integrate mobile robots by interfacing with airo-tulip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project uses a [CalVer](https://calver.org/) versioning scheme with monthly
 - `Zed2i.ULTRA_DEPTH_MODE` to enable the ultra depth setting for the Zed2i cameras
 - `OpenCVVideoCapture` implementation of `RGBCamera` for working with arbitrary cameras
 - `MultiprocessRGBRerunLogger` and `MultiprocessRGBDRerunLogger` now allow you to pass an `entity_path` value which determines where the RGB and depth images will be logged
+- `MobileRobot` and `KELORobile` interface and subclass added, to control mobile robots via the `airo-tulip` package
 
 ### Changed
 - `coco-to-yolo` conversion now creates a single polygon of all disconnected parts of the mask instead of simply taking the first polygon of the list.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Repositories that follow the same style as `airo-mono` packages, but are not par
 | 🛒 [`airo-models`](https://github.com/airo-ugent/airo-models)   | Collection of robot and object models and URDFs |
 | 🐉 [`airo-drake`](https://github.com/airo-ugent/airo-drake)     | Integration with Drake                          |
 | 🧭 [`airo-planner`](https://github.com/airo-ugent/airo-planner) | Motion planning interfaces      |
+| 🚗 [`airo-tulip`](https://github.com/airo-ugent/airo-tulip) | Driver for the KELO mobile robot platform |
 
 ### Usage & Philosophy 📖
 We believe in *keep simple things simple*. Starting a new project should\* be as simple as:

--- a/airo-camera-toolkit/airo_camera_toolkit/cameras/zed/zed2i.py
+++ b/airo-camera-toolkit/airo_camera_toolkit/cameras/zed/zed2i.py
@@ -108,6 +108,7 @@ class Zed2i(StereoRGBDCamera):
         # https://www.stereolabs.com/docs/depth-sensing/depth-settings/
         self.camera_params.depth_mode = depth_mode
         self.camera_params.coordinate_units = sl.UNIT.METER
+        self.camera_params.coordinate_system = sl.COORDINATE_SYSTEM.RIGHT_HANDED_Z_UP_X_FWD
         # objects closerby will have artifacts so they are filtered out (querying them will give a - Infinty)
         self.camera_params.depth_minimum_distance = 0.3
         self.camera_params.depth_maximum_distance = 10.0  # filter out far away objects

--- a/airo-camera-toolkit/airo_camera_toolkit/cameras/zed/zed2i.py
+++ b/airo-camera-toolkit/airo_camera_toolkit/cameras/zed/zed2i.py
@@ -108,7 +108,6 @@ class Zed2i(StereoRGBDCamera):
         # https://www.stereolabs.com/docs/depth-sensing/depth-settings/
         self.camera_params.depth_mode = depth_mode
         self.camera_params.coordinate_units = sl.UNIT.METER
-        self.camera_params.coordinate_system = sl.COORDINATE_SYSTEM.RIGHT_HANDED_Z_UP_X_FWD
         # objects closerby will have artifacts so they are filtered out (querying them will give a - Infinty)
         self.camera_params.depth_minimum_distance = 0.3
         self.camera_params.depth_maximum_distance = 10.0  # filter out far away objects

--- a/airo-robots/airo_robots/drives/hardware/kelo_robile.py
+++ b/airo-robots/airo_robots/drives/hardware/kelo_robile.py
@@ -4,8 +4,8 @@ import time
 import numpy as np
 from airo_robots.awaitable_action import AwaitableAction
 from airo_robots.drives.mobile_robot import CompliantLevel, MobileRobot
-from airo_tulip.platform_driver import PlatformDriverType
-from airo_tulip.server.kelo_robile import KELORobile as KELORobileClient
+from airo_tulip.platform_driver import PlatformDriverType  # type: ignore
+from airo_tulip.server.kelo_robile import KELORobile as KELORobileClient  # type: ignore
 from airo_typing import Vector3DType
 
 
@@ -66,7 +66,7 @@ class KELORobile(MobileRobot):
         action_start_time = time.time_ns()
         action_timeout_time = action_start_time + timeout * 1e9
 
-        def control_loop():
+        def control_loop() -> None:
             current_pose = self._kelo_robile.get_odometry()
             delta_pose = target_pose - current_pose
 
@@ -96,7 +96,9 @@ class KELORobile(MobileRobot):
             default_sleep_resolution=0.002,
         )
 
-    def enable_compliant_mode(self, enabled: bool, compliant_level: CompliantLevel = CompliantLevel.COMPLIANT_WEAK):
+    def enable_compliant_mode(
+        self, enabled: bool, compliant_level: CompliantLevel = CompliantLevel.COMPLIANT_WEAK
+    ) -> None:
         if enabled:
             if compliant_level == CompliantLevel.COMPLIANT_WEAK:
                 self._kelo_robile.set_driver_type(PlatformDriverType.COMPLIANT_WEAK)
@@ -113,5 +115,5 @@ class KELORobile(MobileRobot):
     def get_velocity(self) -> Vector3DType:
         return self._kelo_robile.get_velocity()
 
-    def reset_odometry(self):
+    def reset_odometry(self) -> None:
         self._kelo_robile.reset_odometry()

--- a/airo-robots/airo_robots/drives/hardware/kelo_robile.py
+++ b/airo-robots/airo_robots/drives/hardware/kelo_robile.py
@@ -4,8 +4,8 @@ import time
 import numpy as np
 from airo_robots.awaitable_action import AwaitableAction
 from airo_robots.drives.mobile_robot import CompliantLevel, MobileRobot
-from airo_tulip.platform_driver import PlatformDriverType  # type: ignore
-from airo_tulip.server.kelo_robile import KELORobile as KELORobileClient  # type: ignore
+from airo_tulip.api.client import KELORobile as KELORobileClient  # type: ignore
+from airo_tulip.hardware.platform_driver import PlatformDriverType  # type: ignore
 from airo_typing import Vector3DType
 
 

--- a/airo-robots/airo_robots/drives/hardware/kelo_robile.py
+++ b/airo-robots/airo_robots/drives/hardware/kelo_robile.py
@@ -5,7 +5,7 @@ from airo_tulip.platform_driver import PlatformDriverType
 from airo_tulip.server.kelo_robile import KELORobile as KELORobileClient
 
 from airo_robots.awaitable_action import AwaitableAction
-from airo_robots.drives.mobile_robot import MobileRobot
+from airo_robots.drives.mobile_robot import MobileRobot, CompliantLevel
 
 
 class KELORobile(MobileRobot):
@@ -55,11 +55,11 @@ class KELORobile(MobileRobot):
 
         return AwaitableAction(timeout_awaitable)
 
-    def enable_compliant_mode(self, enabled: bool, compliant_level: int = 1):  # TODO: Use enum variants, document.
+    def enable_compliant_mode(self, enabled: bool, compliant_level: CompliantLevel = CompliantLevel.COMPLIANT_WEAK):
         if enabled:
-            if compliant_level == 1:
+            if compliant_level == CompliantLevel.COMPLIANT_WEAK:
                 self._kelo_robile.set_driver_type(PlatformDriverType.COMPLIANT_WEAK)
-            elif compliant_level == 2:
+            elif compliant_level == CompliantLevel.COMPLIANT_MODERATE:
                 self._kelo_robile.set_driver_type(PlatformDriverType.COMPLIANT_MODERATE)
             else:
                 self._kelo_robile.set_driver_type(PlatformDriverType.COMPLIANT_STRONG)

--- a/airo-robots/airo_robots/drives/hardware/kelo_robile.py
+++ b/airo-robots/airo_robots/drives/hardware/kelo_robile.py
@@ -1,11 +1,11 @@
 import time
 from functools import partial
 
-from airo_tulip.platform_driver import PlatformDriverType
-from airo_tulip.server.kelo_robile import KELORobile as KELORobileClient
-
 from airo_robots.awaitable_action import AwaitableAction
 from airo_robots.drives.mobile_robot import MobileRobot, CompliantLevel
+from airo_tulip.platform_driver import PlatformDriverType
+from airo_tulip.server.kelo_robile import KELORobile as KELORobileClient
+from airo_typing import Vector3DType
 
 
 class KELORobile(MobileRobot):
@@ -65,3 +65,6 @@ class KELORobile(MobileRobot):
                 self._kelo_robile.set_driver_type(PlatformDriverType.COMPLIANT_STRONG)
         else:
             self._kelo_robile.set_driver_type(PlatformDriverType.VELOCITY)
+
+    def get_odometry(self) -> Vector3DType:
+        return self._kelo_robile.get_odometry()

--- a/airo-robots/airo_robots/drives/hardware/kelo_robile.py
+++ b/airo-robots/airo_robots/drives/hardware/kelo_robile.py
@@ -109,3 +109,6 @@ class KELORobile(MobileRobot):
 
     def get_odometry(self) -> Vector3DType:
         return self._kelo_robile.get_odometry()
+
+    def reset_odometry(self):
+        self._kelo_robile.reset_odometry()

--- a/airo-robots/airo_robots/drives/hardware/kelo_robile.py
+++ b/airo-robots/airo_robots/drives/hardware/kelo_robile.py
@@ -2,7 +2,7 @@ import time
 from functools import partial
 
 from airo_robots.awaitable_action import AwaitableAction
-from airo_robots.drives.mobile_robot import MobileRobot, CompliantLevel
+from airo_robots.drives.mobile_robot import CompliantLevel, MobileRobot
 from airo_tulip.platform_driver import PlatformDriverType
 from airo_tulip.server.kelo_robile import KELORobile as KELORobileClient
 from airo_typing import Vector3DType

--- a/airo-robots/airo_robots/drives/hardware/kelo_robile.py
+++ b/airo-robots/airo_robots/drives/hardware/kelo_robile.py
@@ -15,14 +15,16 @@ class KELORobile(MobileRobot):
     be controlled individually. The airo-tulip API, which is used here, provides a higher level interface which
     controls the entire platform."""
 
-    def __init__(self, robot_ip: str, robot_port: int):
+    def __init__(self, robot_ip: str, robot_port: int = 49789):
         """Connect to the KELO robot.
 
-        The KELO robot should already be running the airo-tulip server.
+        The KELO robot should already be running the airo-tulip server. If this is not the case, any messages
+        sent from the client may be queued and executed once the server is started, resulting in unexpected
+        and/or sudden movements.
 
         Args:
             robot_ip: IP address of the KELO CPU brick.
-            robot_port: Port to connect on."""
+            robot_port: Port to connect on (default: 49789)."""
         self._kelo_robile = KELORobileClient(robot_ip, robot_port)
 
     def align_drives(self, x: float, y: float, a: float, timeout: float = 1.0) -> AwaitableAction:

--- a/airo-robots/airo_robots/drives/hardware/kelo_robile.py
+++ b/airo-robots/airo_robots/drives/hardware/kelo_robile.py
@@ -47,7 +47,7 @@ class KELORobile(MobileRobot):
         return AwaitableAction(partial(aligned_awaitable, time.time()))
 
     def set_platform_velocity_target(self, x: float, y: float, a: float, timeout: float) -> AwaitableAction:
-        self._kelo_robile.set_platform_velocity_target(x, y, a, timeout=timeout, instantaneous=True)
+        self._kelo_robile.set_platform_velocity_target(x, y, a, timeout=timeout)
 
         def timeout_awaitable() -> bool:
             time.sleep(timeout)

--- a/airo-robots/airo_robots/drives/hardware/kelo_robile.py
+++ b/airo-robots/airo_robots/drives/hardware/kelo_robile.py
@@ -38,8 +38,13 @@ class KELORobile(MobileRobot):
 
         return AwaitableAction(timeout_awaitable)
 
-    def enable_compliant_mode(self, enabled: bool):
+    def enable_compliant_mode(self, enabled: bool, compliant_level: int = 1):  # TODO: Use enum variants, document.
         if enabled:
-            self._kelo_robile.set_driver_type(PlatformDriverType.COMPLIANT)
+            if compliant_level == 1:
+                self._kelo_robile.set_driver_type(PlatformDriverType.COMPLIANT_WEAK)
+            elif compliant_level == 2:
+                self._kelo_robile.set_driver_type(PlatformDriverType.COMPLIANT_MODERATE)
+            else:
+                self._kelo_robile.set_driver_type(PlatformDriverType.COMPLIANT_STRONG)
         else:
             self._kelo_robile.set_driver_type(PlatformDriverType.VELOCITY)

--- a/airo-robots/airo_robots/drives/hardware/kelo_robile.py
+++ b/airo-robots/airo_robots/drives/hardware/kelo_robile.py
@@ -82,7 +82,7 @@ class KELORobile(MobileRobot):
             if command_timeout >= 0.0:
                 self._kelo_robile.set_platform_velocity_target(vel_x, vel_y, vel_a, timeout=command_timeout)
 
-            at_target_pose = np.linalg.norm(delta_pose) < 0.01
+            at_target_pose = bool(np.linalg.norm(delta_pose) < 0.01)
             stop = at_target_pose or time.time_ns() - action_start_time > timeout * 1e9
 
             if stop:

--- a/airo-robots/airo_robots/drives/hardware/kelo_robile.py
+++ b/airo-robots/airo_robots/drives/hardware/kelo_robile.py
@@ -110,5 +110,8 @@ class KELORobile(MobileRobot):
     def get_odometry(self) -> Vector3DType:
         return self._kelo_robile.get_odometry()
 
+    def get_velocity(self) -> Vector3DType:
+        return self._kelo_robile.get_velocity()
+
     def reset_odometry(self):
         self._kelo_robile.reset_odometry()

--- a/airo-robots/airo_robots/drives/hardware/kelo_robile.py
+++ b/airo-robots/airo_robots/drives/hardware/kelo_robile.py
@@ -1,0 +1,32 @@
+import time
+
+from airo_robots.awaitable_action import AwaitableAction
+from airo_robots.drives.mobile_robot import MobileRobot
+from airo_tulip.server.kelo_robile import KELORobile as KELORobileClient
+
+
+class KELORobile(MobileRobot):
+    """KELO Robile platform implementation of the MobileRobot interface.
+
+    The KELO Robile platform consists of several drives with castor wheels which are connected via EtherCAT and can
+    be controlled individually. The airo-tulip API, which is used here, provides a higher level interface which
+    controls the entire platform."""
+
+    def __init__(self, robot_ip: str, robot_port: int):
+        """Connect to the KELO robot.
+
+        The KELO robot should already be running the airo-tulip server.
+
+        Args:
+            robot_ip: IP address of the KELO CPU brick.
+            robot_port: Port to connect on."""
+        self._kelo_robile = KELORobileClient(robot_ip, robot_port)
+
+    def set_platform_velocity_target(self, x: float, y: float, a: float, timeout: float) -> AwaitableAction:
+        self._kelo_robile.set_platform_velocity_target(x, y, a, timeout)
+
+        def timeout_awaitable() -> bool:
+            time.sleep(timeout)
+            return True
+
+        return AwaitableAction(timeout_awaitable)

--- a/airo-robots/airo_robots/drives/hardware/kelo_robile.py
+++ b/airo-robots/airo_robots/drives/hardware/kelo_robile.py
@@ -79,7 +79,8 @@ class KELORobile(MobileRobot):
             vel_a = max(min(delta_angle, math.pi / 4), -math.pi / 4)
 
             command_timeout = (action_timeout_time - time.time_ns()) * 1e-9
-            self._kelo_robile.set_platform_velocity_target(vel_x, vel_y, vel_a, timeout=command_timeout)
+            if command_timeout >= 0.0:
+                self._kelo_robile.set_platform_velocity_target(vel_x, vel_y, vel_a, timeout=command_timeout)
 
             at_target_pose = np.linalg.norm(delta_pose) < 0.01
             stop = at_target_pose or time.time_ns() - action_start_time > timeout * 1e9

--- a/airo-robots/airo_robots/drives/hardware/kelo_robile.py
+++ b/airo-robots/airo_robots/drives/hardware/kelo_robile.py
@@ -68,7 +68,7 @@ class KELORobile(MobileRobot):
 
     def _move_platform_to_pose_control_loop(
         self, target_pose: Vector3DType, action_start_time: float, action_timeout_time: float, timeout: float
-    ):
+    ) -> None:
         stop = False
         while not stop:
             current_pose = self._kelo_robile.get_odometry()

--- a/airo-robots/airo_robots/drives/hardware/kelo_robile.py
+++ b/airo-robots/airo_robots/drives/hardware/kelo_robile.py
@@ -66,7 +66,7 @@ class KELORobile(MobileRobot):
         action_start_time = time.time_ns()
         action_timeout_time = action_start_time + timeout * 1e9
 
-        def control_loop() -> None:
+        def control_loop() -> bool:
             current_pose = self._kelo_robile.get_odometry()
             delta_pose = target_pose - current_pose
 

--- a/airo-robots/airo_robots/drives/hardware/kelo_robile_setup.md
+++ b/airo-robots/airo_robots/drives/hardware/kelo_robile_setup.md
@@ -1,0 +1,1 @@
+For information on how to set up the KELO Robile, please refer to the documentation of [airo-tulip](https://pypi.org/project/airo-tulip/).

--- a/airo-robots/airo_robots/drives/hardware/manual_robot_testing.py
+++ b/airo-robots/airo_robots/drives/hardware/manual_robot_testing.py
@@ -1,7 +1,7 @@
 """code for manual testing of mobile robot base class implementations.
 """
-from airo_robots.drives.mobile_robot import MobileRobot
 from airo_robots.drives.hardware.kelo_robile import KELORobile
+from airo_robots.drives.mobile_robot import MobileRobot
 
 
 def manually_test_robot_implementation(robot: MobileRobot) -> None:

--- a/airo-robots/airo_robots/drives/hardware/manual_robot_testing.py
+++ b/airo-robots/airo_robots/drives/hardware/manual_robot_testing.py
@@ -5,14 +5,14 @@ from airo_robots.drives.mobile_robot import MobileRobot
 
 def manually_test_robot_implementation(robot: MobileRobot) -> None:
     input("robot will now move forward 10cm")
-    robot.set_platform_velocity_target(0.1, 0.0, 0.0, 1.0)
+    robot.set_platform_velocity_target(0.1, 0.0, 0.0, 1.0).wait()
 
     input("robot will now move left 10cm")
-    robot.set_platform_velocity_target(0.0, 0.1, 0.0, 1.0)
+    robot.set_platform_velocity_target(0.0, 0.1, 0.0, 1.0).wait()
 
     input("robot will now make two short rotations")
-    robot.set_platform_velocity_target(0.0, 0.0, 0.1, 1.0)
-    robot.set_platform_velocity_target(0.0, 0.0, -0.1, 1.0)
+    robot.set_platform_velocity_target(0.0, 0.0, 0.1, 1.0).wait()
+    robot.set_platform_velocity_target(0.0, 0.0, -0.1, 1.0).wait()
 
     input("robot will now return to original position")
-    robot.set_platform_velocity_target(-0.1, -0.1, 0.0, 1.0)
+    robot.set_platform_velocity_target(-0.1, -0.1, 0.0, 1.0).wait()

--- a/airo-robots/airo_robots/drives/hardware/manual_robot_testing.py
+++ b/airo-robots/airo_robots/drives/hardware/manual_robot_testing.py
@@ -9,29 +9,21 @@ def manually_test_robot_implementation(robot: MobileRobot) -> None:
         input("robot will rotate drives")
         robot.align_drives(0.1, 0.0, 0.0, 1.0).wait()
 
-    # input("robot will now move forward 10cm")
-    # robot.set_platform_velocity_target(0.1, 0.0, 0.0, 1.0).wait()
+    input("robot will now move forward 10cm")
+    robot.set_platform_velocity_target(0.1, 0.0, 0.0, 1.0).wait()
 
-    # input("robot will now move left 10cm")
-    # robot.set_platform_velocity_target(0.0, 0.1, 0.0, 1.0).wait()
+    input("robot will now move left 10cm")
+    robot.set_platform_velocity_target(0.0, 0.1, 0.0, 1.0).wait()
 
-    # input("robot will now make two short rotations")
-    # robot.set_platform_velocity_target(0.0, 0.0, 0.1, 1.0).wait()
-    # robot.set_platform_velocity_target(0.0, 0.0, -0.1, 1.0).wait()
+    input("robot will now make two short rotations")
+    robot.set_platform_velocity_target(0.0, 0.0, 0.1, 1.0).wait()
+    robot.set_platform_velocity_target(0.0, 0.0, -0.1, 1.0).wait()
 
-    # input("robot will now return to original position")
-    # robot.set_platform_velocity_target(-0.1, -0.1, 0.0, 1.0).wait()
+    input("robot will now return to original position")
+    robot.set_platform_velocity_target(-0.1, -0.1, 0.0, 1.0).wait()
 
-    # robot.enable_compliant_mode(True, CompliantLevel.COMPLIANT_STRONG)
-
-    robot.move_platform_to_pose(1.2, 0.0, 0.0, 10.0).wait()
-    print(robot.get_odometry())
-
-    robot.move_platform_to_pose(1.8, 0.6, 3.14 / 2, 10.0).wait()
-    print(robot.get_odometry())
-
-    robot.move_platform_to_pose(1.8, 1.0, 3.14 / 2, 10.0).wait()
-    print(robot.get_odometry())
+    input("robot will now move to 10 cm along +X relative from its starting position with position control")
+    robot.move_platform_to_pose(0.1, 0.0, 0.0, 10.0).wait()
 
 
 if __name__ == "__main__":

--- a/airo-robots/airo_robots/drives/hardware/manual_robot_testing.py
+++ b/airo-robots/airo_robots/drives/hardware/manual_robot_testing.py
@@ -9,18 +9,31 @@ def manually_test_robot_implementation(robot: MobileRobot) -> None:
         input("robot will rotate drives")
         robot.align_drives(0.1, 0.0, 0.0, 1.0).wait()
 
-    input("robot will now move forward 10cm")
-    robot.set_platform_velocity_target(0.1, 0.0, 0.0, 1.0).wait()
+    # input("robot will now move forward 10cm")
+    # robot.set_platform_velocity_target(0.1, 0.0, 0.0, 1.0).wait()
 
-    input("robot will now move left 10cm")
-    robot.set_platform_velocity_target(0.0, 0.1, 0.0, 1.0).wait()
+    # input("robot will now move left 10cm")
+    # robot.set_platform_velocity_target(0.0, 0.1, 0.0, 1.0).wait()
 
-    input("robot will now make two short rotations")
-    robot.set_platform_velocity_target(0.0, 0.0, 0.1, 1.0).wait()
-    robot.set_platform_velocity_target(0.0, 0.0, -0.1, 1.0).wait()
+    # input("robot will now make two short rotations")
+    # robot.set_platform_velocity_target(0.0, 0.0, 0.1, 1.0).wait()
+    # robot.set_platform_velocity_target(0.0, 0.0, -0.1, 1.0).wait()
 
-    input("robot will now return to original position")
-    robot.set_platform_velocity_target(-0.1, -0.1, 0.0, 1.0).wait()
+    # input("robot will now return to original position")
+    # robot.set_platform_velocity_target(-0.1, -0.1, 0.0, 1.0).wait()
 
-    input("robot will now move to the pose (30 cm, 60 cm, pi/4 rad)")
-    robot.move_platform_to_pose(0.3, 0.6, 3.14 / 4, 5.0).wait()
+    # robot.enable_compliant_mode(True, CompliantLevel.COMPLIANT_STRONG)
+
+    robot.move_platform_to_pose(1.2, 0.0, 0.0, 10.0).wait()
+    print(robot.get_odometry())
+
+    robot.move_platform_to_pose(1.8, 0.6, 3.14 / 2, 10.0).wait()
+    print(robot.get_odometry())
+
+    robot.move_platform_to_pose(1.8, 1.0, 3.14 / 2, 10.0).wait()
+    print(robot.get_odometry())
+
+
+if __name__ == "__main__":
+    mobi = KELORobile("10.10.129.21")
+    manually_test_robot_implementation(mobi)

--- a/airo-robots/airo_robots/drives/hardware/manual_robot_testing.py
+++ b/airo-robots/airo_robots/drives/hardware/manual_robot_testing.py
@@ -1,9 +1,14 @@
 """code for manual testing of mobile robot base class implementations.
 """
 from airo_robots.drives.mobile_robot import MobileRobot
+from airo_robots.drives.hardware.kelo_robile import KELORobile
 
 
 def manually_test_robot_implementation(robot: MobileRobot) -> None:
+    if isinstance(robot, KELORobile):
+        input("robot will rotate drives")
+        robot.align_drives(0.1, 0.0, 0.0, 1.0).wait()
+
     input("robot will now move forward 10cm")
     robot.set_platform_velocity_target(0.1, 0.0, 0.0, 1.0).wait()
 

--- a/airo-robots/airo_robots/drives/hardware/manual_robot_testing.py
+++ b/airo-robots/airo_robots/drives/hardware/manual_robot_testing.py
@@ -1,0 +1,18 @@
+"""code for manual testing of mobile robot base class implementations.
+"""
+from airo_robots.drives.mobile_robot import MobileRobot
+
+
+def manually_test_robot_implementation(robot: MobileRobot) -> None:
+    input("robot will now move forward 10cm")
+    robot.set_platform_velocity_target(0.1, 0.0, 0.0, 1.0)
+
+    input("robot will now move left 10cm")
+    robot.set_platform_velocity_target(0.0, 0.1, 0.0, 1.0)
+
+    input("robot will now make two short rotations")
+    robot.set_platform_velocity_target(0.0, 0.0, 0.1, 1.0)
+    robot.set_platform_velocity_target(0.0, 0.0, -0.1, 1.0)
+
+    input("robot will now return to original position")
+    robot.set_platform_velocity_target(-0.1, -0.1, 0.0, 1.0)

--- a/airo-robots/airo_robots/drives/hardware/manual_robot_testing.py
+++ b/airo-robots/airo_robots/drives/hardware/manual_robot_testing.py
@@ -21,3 +21,6 @@ def manually_test_robot_implementation(robot: MobileRobot) -> None:
 
     input("robot will now return to original position")
     robot.set_platform_velocity_target(-0.1, -0.1, 0.0, 1.0).wait()
+
+    input("robot will now move to the pose (30 cm, 60 cm, pi/4 rad)")
+    robot.move_platform_to_pose(0.3, 0.6, 3.14 / 4, 5.0).wait()

--- a/airo-robots/airo_robots/drives/mobile_robot.py
+++ b/airo-robots/airo_robots/drives/mobile_robot.py
@@ -4,11 +4,13 @@ from enum import Enum
 from airo_robots.awaitable_action import AwaitableAction
 from airo_typing import Vector3DType
 
+
 class CompliantLevel(Enum):
     """The level of compliance expected from the mobile robot.
 
     Values may not correspond to identical behaviour on different mobile platforms, but are merely an indication.
     A value of weak means a very compliant robot, whereas a value of strong means a slightly compliant robot."""
+
     COMPLIANT_WEAK = 1
     COMPLIANT_MODERATE = 2
     COMPLIANT_STRONG = 3

--- a/airo-robots/airo_robots/drives/mobile_robot.py
+++ b/airo-robots/airo_robots/drives/mobile_robot.py
@@ -68,3 +68,7 @@ class MobileRobot(ABC):
         robot's starting pose.
 
         Returns: A 3D vector with a value for the `x` position, `y` position, and `theta` angle of the robot."""
+
+    @abstractmethod
+    def reset_odometry(self):
+        """Reset the robot's odometry to `(0, 0, 0)`."""

--- a/airo-robots/airo_robots/drives/mobile_robot.py
+++ b/airo-robots/airo_robots/drives/mobile_robot.py
@@ -1,0 +1,29 @@
+from abc import ABC, abstractmethod
+
+from airo_robots.awaitable_action import AwaitableAction
+
+
+class MobileRobot(ABC):
+    """
+    Base class for a mobile robot.
+
+    Mobile robots typically allow to set a target velocity for the entire platform and apply torques to their wheels
+    to achieve the desired velocity.
+
+    All values are in metric units:
+    - Linear velocities are expressed in meters/second
+    - Angular velocities are expressed in radians/second
+    """
+
+    @abstractmethod
+    def set_platform_velocity_target(self, x: float, y: float, a: float, timeout: float) -> AwaitableAction:
+        """Set the desired platform velocity.
+
+        Args:
+            x: Linear velocity along the X axis.
+            y: Linear velocity along the Y axis.
+            a: Angular velocity.
+            timeout: After this time, the platform will automatically stop.
+
+        Returns:
+            An awaitable action."""

--- a/airo-robots/airo_robots/drives/mobile_robot.py
+++ b/airo-robots/airo_robots/drives/mobile_robot.py
@@ -16,7 +16,8 @@ class MobileRobot(ABC):
     """
 
     @abstractmethod
-    def set_platform_velocity_target(self, x: float, y: float, a: float, timeout: float) -> AwaitableAction:
+    def set_platform_velocity_target(self, x: float, y: float, a: float, timeout: float,
+                                     align_drives_first: bool = False) -> AwaitableAction:
         """Set the desired platform velocity.
 
         Args:
@@ -24,6 +25,14 @@ class MobileRobot(ABC):
             y: Linear velocity along the Y axis.
             a: Angular velocity.
             timeout: After this time, the platform will automatically stop.
+            align_drives_first: Align drives before moving (default: False, will start driving instantly).
 
         Returns:
             An awaitable action."""
+
+    @abstractmethod
+    def enable_compliant_mode(self, enabled: bool):
+        """Enable compliant mode on the robot.
+
+        Args:
+            enabled: If true, will enable compliant mode. Else, will disable compliant mode."""

--- a/airo-robots/airo_robots/drives/mobile_robot.py
+++ b/airo-robots/airo_robots/drives/mobile_robot.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from enum import Enum
 
 from airo_robots.awaitable_action import AwaitableAction
+from airo_typing import Vector3DType
 
 class CompliantLevel(Enum):
     """The level of compliance expected from the mobile robot.
@@ -26,8 +27,7 @@ class MobileRobot(ABC):
     """
 
     @abstractmethod
-    def set_platform_velocity_target(self, x: float, y: float, a: float, timeout: float,
-                                     align_drives_first: bool = False) -> AwaitableAction:
+    def set_platform_velocity_target(self, x: float, y: float, a: float, timeout: float) -> AwaitableAction:
         """Set the desired platform velocity.
 
         Args:
@@ -35,7 +35,6 @@ class MobileRobot(ABC):
             y: Linear velocity along the Y axis.
             a: Angular velocity.
             timeout: After this time, the platform will automatically stop.
-            align_drives_first: Align drives before moving (default: False, will start driving instantly).
 
         Returns:
             An awaitable action."""
@@ -47,3 +46,10 @@ class MobileRobot(ABC):
         Args:
             enabled: If true, will enable compliant mode. Else, will disable compliant mode.
             compliant_level: The level of compliance to be expected from the robot. Ignored if `enabled` is `False`."""
+
+    @abstractmethod
+    def get_odometry(self) -> Vector3DType:
+        """Get the estimated robot pose as a 3D vector comprising the `x`, `y`, and `theta` values relative to the
+        robot's starting pose.
+
+        Returns: A 3D vector with a value for the `x` position, `y` position, and `theta` angle of the robot."""

--- a/airo-robots/airo_robots/drives/mobile_robot.py
+++ b/airo-robots/airo_robots/drives/mobile_robot.py
@@ -42,6 +42,19 @@ class MobileRobot(ABC):
             An awaitable action."""
 
     @abstractmethod
+    def move_platform_to_pose(self, x: float, y: float, a: float, timeout: float) -> AwaitableAction:
+        """Move the platform to the given pose, without guarantees about the followed path.
+
+        Args:
+            x: Position along the startup pose's X axis.
+            y: Position along the startup pose's Y axis.
+            a: Orientation around the startup pose's Z axis..
+            timeout: After this time, the platform will automatically stop.
+
+        Returns:
+            An awaitable action."""
+
+    @abstractmethod
     def enable_compliant_mode(self, enabled: bool, compliant_level: CompliantLevel):
         """Enable compliant mode on the robot.
 

--- a/airo-robots/airo_robots/drives/mobile_robot.py
+++ b/airo-robots/airo_robots/drives/mobile_robot.py
@@ -72,3 +72,11 @@ class MobileRobot(ABC):
     @abstractmethod
     def reset_odometry(self):
         """Reset the robot's odometry to `(0, 0, 0)`."""
+
+    @abstractmethod
+    def get_velocity(self) -> Vector3DType:
+        """Get the estimated robot's velocity as a 3D vector comprising the `x`, `y` and `theta` values relative to the
+        robot's starting pose.
+
+        Returns:
+            A 3D vector with a value for the `x` velocity, `y` velocity, and `theta` angular velocity of the robot."""

--- a/airo-robots/airo_robots/drives/mobile_robot.py
+++ b/airo-robots/airo_robots/drives/mobile_robot.py
@@ -1,6 +1,16 @@
 from abc import ABC, abstractmethod
+from enum import Enum
 
 from airo_robots.awaitable_action import AwaitableAction
+
+class CompliantLevel(Enum):
+    """The level of compliance expected from the mobile robot.
+
+    Values may not correspond to identical behaviour on different mobile platforms, but are merely an indication.
+    A value of weak means a very compliant robot, whereas a value of strong means a slightly compliant robot."""
+    COMPLIANT_WEAK = 1
+    COMPLIANT_MODERATE = 2
+    COMPLIANT_STRONG = 3
 
 
 class MobileRobot(ABC):
@@ -31,8 +41,9 @@ class MobileRobot(ABC):
             An awaitable action."""
 
     @abstractmethod
-    def enable_compliant_mode(self, enabled: bool):
+    def enable_compliant_mode(self, enabled: bool, compliant_level: CompliantLevel):
         """Enable compliant mode on the robot.
 
         Args:
-            enabled: If true, will enable compliant mode. Else, will disable compliant mode."""
+            enabled: If true, will enable compliant mode. Else, will disable compliant mode.
+            compliant_level: The level of compliance to be expected from the robot. Ignored if `enabled` is `False`."""

--- a/airo-robots/airo_robots/drives/mobile_robot.py
+++ b/airo-robots/airo_robots/drives/mobile_robot.py
@@ -48,7 +48,7 @@ class MobileRobot(ABC):
         Args:
             x: Position along the startup pose's X axis.
             y: Position along the startup pose's Y axis.
-            a: Orientation around the startup pose's Z axis..
+            a: Orientation around the startup pose's Z axis.
             timeout: After this time, the platform will automatically stop.
 
         Returns:

--- a/airo-robots/airo_robots/drives/mobile_robot.py
+++ b/airo-robots/airo_robots/drives/mobile_robot.py
@@ -55,7 +55,7 @@ class MobileRobot(ABC):
             An awaitable action."""
 
     @abstractmethod
-    def enable_compliant_mode(self, enabled: bool, compliant_level: CompliantLevel):
+    def enable_compliant_mode(self, enabled: bool, compliant_level: CompliantLevel) -> None:
         """Enable compliant mode on the robot.
 
         Args:
@@ -70,7 +70,7 @@ class MobileRobot(ABC):
         Returns: A 3D vector with a value for the `x` position, `y` position, and `theta` angle of the robot."""
 
     @abstractmethod
-    def reset_odometry(self):
+    def reset_odometry(self) -> None:
         """Reset the robot's odometry to `(0, 0, 0)`."""
 
     @abstractmethod

--- a/airo-robots/setup.py
+++ b/airo-robots/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
         "click",
         "airo-typing",
         "airo-spatial-algebra",
-        "airo-tulip==0.0.4",
+        "airo-tulip==0.0.5",
     ],
     packages=setuptools.find_packages(),
     package_data={"airo_robots": ["py.typed"]},

--- a/airo-robots/setup.py
+++ b/airo-robots/setup.py
@@ -15,6 +15,7 @@ setuptools.setup(
         "click",
         "airo-typing",
         "airo-spatial-algebra",
+        "airo-tulip==0.0.1a0",
     ],
     packages=setuptools.find_packages(),
     package_data={"airo_robots": ["py.typed"]},

--- a/airo-robots/setup.py
+++ b/airo-robots/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
         "click",
         "airo-typing",
         "airo-spatial-algebra",
-        "airo-tulip==0.0.5",
+        "airo-tulip==0.0.6",
     ],
     packages=setuptools.find_packages(),
     package_data={"airo_robots": ["py.typed"]},

--- a/airo-robots/setup.py
+++ b/airo-robots/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
         "click",
         "airo-typing",
         "airo-spatial-algebra",
-        "airo-tulip==0.0.3",
+        "airo-tulip==0.0.4",
     ],
     packages=setuptools.find_packages(),
     package_data={"airo_robots": ["py.typed"]},

--- a/airo-robots/setup.py
+++ b/airo-robots/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
         "click",
         "airo-typing",
         "airo-spatial-algebra",
-        "airo-tulip==0.0.8",
+        "airo-tulip==0.0.9",
     ],
     packages=setuptools.find_packages(),
     package_data={"airo_robots": ["py.typed"]},

--- a/airo-robots/setup.py
+++ b/airo-robots/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
         "click",
         "airo-typing",
         "airo-spatial-algebra",
-        "airo-tulip==0.0.6",
+        "airo-tulip==0.0.7",
     ],
     packages=setuptools.find_packages(),
     package_data={"airo_robots": ["py.typed"]},

--- a/airo-robots/setup.py
+++ b/airo-robots/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
         "click",
         "airo-typing",
         "airo-spatial-algebra",
-        "airo-tulip==0.0.7",
+        "airo-tulip==0.0.8",
     ],
     packages=setuptools.find_packages(),
     package_data={"airo_robots": ["py.typed"]},

--- a/airo-robots/setup.py
+++ b/airo-robots/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
         "click",
         "airo-typing",
         "airo-spatial-algebra",
-        "airo-tulip==0.0.9",
+        "airo-tulip==0.0.10",
     ],
     packages=setuptools.find_packages(),
     package_data={"airo_robots": ["py.typed"]},

--- a/airo-robots/setup.py
+++ b/airo-robots/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
         "click",
         "airo-typing",
         "airo-spatial-algebra",
-        "airo-tulip==0.0.10",
+        "airo-tulip==0.1.0",
     ],
     packages=setuptools.find_packages(),
     package_data={"airo_robots": ["py.typed"]},

--- a/airo-robots/setup.py
+++ b/airo-robots/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
         "click",
         "airo-typing",
         "airo-spatial-algebra",
-        "airo-tulip==0.0.1a0",
+        "airo-tulip==0.0.3",
     ],
     packages=setuptools.find_packages(),
     package_data={"airo_robots": ["py.typed"]},


### PR DESCRIPTION
## Describe your changes

This branch integrates with [airo-tulip](https://github.com/airo-ugent/airo-tulip) - currently at version `0.1.0` - to control our KELO mobile platform. The contributions are located in `airo-robots`, and are fairly limited in scope, with most of the implementation being low-level code that is implemented in the `airo-tulip` repository. The interface in `airo-robots` simply communicates with the KELO platform over TCP (technically, via [0MQ](https://zeromq.org/)), which is abstracted away by the `KELORobile` class.

The contributions follow the existing class structure of `airo-robots`, introducing a `MobileRobot` interface, which is implemented by the `KELORobile` class. The `KELORobile` class also adds some methods that are not present in the interface, because they are specific to the `KELO` robot.

As the `airo-tulip` repository is going to undergo further changes in the near future, this interface in AIRO-mono is also subject to changes. At this time, no breaking changes are expected, but also not ruled out.

## Checklist
- [x] Have you modified the changelog?
- [x] If you made changes to the hardware interfaces, have you tested them using the manual tests?
