### PR TITLE
Closes #143 - Catch RTDE exceptions in constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project uses a [CalVer](https://calver.org/) versioning scheme with monthly
 - `coco-to-yolo` conversion now creates a single polygon of all disconnected parts of the mask instead of simply taking the first polygon of the list.
 - Dropped support for python 3.8 and added 3.11 to the testing matrix [#103](https://github.com/airo-ugent/airo-mono/issues/103).
 - Set python version to 3.10 because of an issue with the `ur_rtde` wheels [#121](https://github.com/airo-ugent/airo-mono/issues/121). Updated README.md to reflect this change.
+- `URrtde` will now try connecting to do control interface up to 3 times before raising a `RuntimeError`.
 
 ### Fixed
 - Fixed bug in `get_colored_point_cloud()` that removed some points see issue #25.

--- a/airo-robots/airo_robots/manipulators/hardware/ur_rtde.py
+++ b/airo-robots/airo_robots/manipulators/hardware/ur_rtde.py
@@ -51,6 +51,7 @@ class URrtde(PositionManipulator):
             try:
                 self.rtde_control = RTDEControlInterface(self.ip_address)
                 self.rtde_receive = RTDEReceiveInterface(self.ip_address)
+                break
             except RuntimeError as e:
                 logger.warning(
                     f"Failed to connect to RTDE. Retrying... (Attempt {connection_attempt + 1}/{max_connection_attempts}). Error:\n{e}"
@@ -59,6 +60,8 @@ class URrtde(PositionManipulator):
                     raise RuntimeError(
                         "Could not connect to the robot. Is the robot in remote control? Is the IP correct? Is the network connection ok?"
                     )
+                else:
+                    time.sleep(1.0)
 
         self.default_linear_acceleration = 1.2  # m/s^2
         self.default_leading_axis_joint_acceleration = 1.2  # rad/s^2


### PR DESCRIPTION
## Describe your changes

When the RTDE connection fails to establish, `URrtde` will now retry up to three times.
This is useful after emergency stops, when the connection sometimes fails.

Closes #143 

## Checklist
- [x] Have you modified the changelog?
- [x] If you made changes to the hardware interfaces, have you tested them using the manual tests?
