### PR TITLE
Lock NumPy to versions below 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This project uses a [CalVer](https://calver.org/) versioning scheme with monthly
 - Set python version to 3.10 because of an issue with the `ur_rtde` wheels [#121](https://github.com/airo-ugent/airo-mono/issues/121). Updated README.md to reflect this change.
 - `URrtde` will now try connecting to do control interface up to 3 times before raising a `RuntimeError`.
 - Renamed `Zed2i` to `Zed` and `zed2i.py` to `zed.py`, but kept the old names as aliases for backwards compatibility
+- Locked `numpy` to versions `<2.0` for compatibility with `opencv`, since we are using a locked version of `opencv` that is not compatible with newer versions of `numpy`.
 
 ### Fixed
 - Fixed bug in `get_colored_point_cloud()` that removed some points see issue #25.

--- a/airo-camera-toolkit/setup.py
+++ b/airo-camera-toolkit/setup.py
@@ -10,7 +10,7 @@ setuptools.setup(
     author="Thomas Lips",
     author_email="thomas.lips@ugent.be",
     install_requires=[
-        "numpy",
+        "numpy<2.0",
         "opencv-contrib-python==4.8.1.78",  # We need opencv contrib for the aruco marker detection, but when some packages install (a different version of) opencv-python-headless, this breaks the contrib version. So we install both here to make sure they are the same version.
         "opencv-python-headless==4.8.1.78",  # Lock to match contrib version.
         "matplotlib",

--- a/airo-dataset-tools/setup.py
+++ b/airo-dataset-tools/setup.py
@@ -10,7 +10,7 @@ setuptools.setup(
     author_email="victorlouisdg@gmail.com",
     description="TODO",
     install_requires=[
-        "numpy",
+        "numpy<2.0",
         "pydantic>2.0.0",  # pydantic 2.0.0 has a lot of breaking changes
         "opencv-contrib-python==4.8.1.78",  # See airo-camera-toolkit setup.py for explanation
         "opencv-python-headless==4.8.1.78",  # See airo-camera-toolkit setup.py for explanation

--- a/airo-robots/airo_robots/grippers/hardware/schunk_egk40_usb.py
+++ b/airo-robots/airo_robots/grippers/hardware/schunk_egk40_usb.py
@@ -44,8 +44,7 @@ class SchunkEGK40_USB(ParallelPositionGripper):
     SCHUNK_DEFAULT_SPECS = ParallelPositionGripperSpecs(0.083, 0.0, 150, 55, 0.0575, 0.0055)
 
     def __init__(
-            self, usb_interface: str = "/dev/ttyUSB0",
-            max_stroke_setting: Optional[SCHUNK_STROKE_OPTIONS | float] = None
+        self, usb_interface: str = "/dev/ttyUSB0", max_stroke_setting: Optional[SCHUNK_STROKE_OPTIONS | float] = None
     ) -> None:
         """
         :param usb_interface: the USB interface to which the gripper is connected.
@@ -122,11 +121,11 @@ class SchunkEGK40_USB(ParallelPositionGripper):
         return self.gripper_specs.max_width - (self.bks.actual_pos / 1000)
 
     def move(
-            self,
-            width: float,
-            speed: Optional[float] = SCHUNK_DEFAULT_SPECS.min_speed,
-            force: Optional[float] = SCHUNK_DEFAULT_SPECS.min_force,
-            set_speed_and_force: bool = True,
+        self,
+        width: float,
+        speed: Optional[float] = SCHUNK_DEFAULT_SPECS.min_speed,
+        force: Optional[float] = SCHUNK_DEFAULT_SPECS.min_force,
+        set_speed_and_force: bool = True,
     ) -> AwaitableAction:
         """
         Move the gripper to a certain position at a certain speed with a certain force. This function is assumed to run
@@ -141,11 +140,11 @@ class SchunkEGK40_USB(ParallelPositionGripper):
         return self.servo(width=width, speed=speed, force=force, set_speed_and_force=set_speed_and_force)
 
     def move_relative(
-            self,
-            width_difference: float,
-            speed: Optional[float] = SCHUNK_DEFAULT_SPECS.min_speed,
-            force: Optional[float] = SCHUNK_DEFAULT_SPECS.min_force,
-            set_speed_and_force: bool = True,
+        self,
+        width_difference: float,
+        speed: Optional[float] = SCHUNK_DEFAULT_SPECS.min_speed,
+        force: Optional[float] = SCHUNK_DEFAULT_SPECS.min_force,
+        set_speed_and_force: bool = True,
     ) -> AwaitableAction:
         """
         Move the gripper to a certain position at a certain speed with a certain force. This function is assumed to run
@@ -170,11 +169,11 @@ class SchunkEGK40_USB(ParallelPositionGripper):
         self.bks.MakeReady()
 
     def servo(
-            self,
-            width: float,
-            speed: Optional[float] = SCHUNK_DEFAULT_SPECS.min_speed,
-            force: Optional[float] = SCHUNK_DEFAULT_SPECS.min_force,
-            set_speed_and_force: bool = True,
+        self,
+        width: float,
+        speed: Optional[float] = SCHUNK_DEFAULT_SPECS.min_speed,
+        force: Optional[float] = SCHUNK_DEFAULT_SPECS.min_force,
+        set_speed_and_force: bool = True,
     ) -> AwaitableAction:
         """
         Move the gripper to a certain position at a certain speed with a certain force. This function is assumed to run
@@ -199,11 +198,11 @@ class SchunkEGK40_USB(ParallelPositionGripper):
         return AwaitableAction(self._move_done_condition)
 
     def servo_relative(
-            self,
-            width_difference: float,
-            speed: Optional[float] = SCHUNK_DEFAULT_SPECS.min_speed,
-            force: Optional[float] = SCHUNK_DEFAULT_SPECS.min_force,
-            set_speed_and_force: bool = True,
+        self,
+        width_difference: float,
+        speed: Optional[float] = SCHUNK_DEFAULT_SPECS.min_speed,
+        force: Optional[float] = SCHUNK_DEFAULT_SPECS.min_force,
+        set_speed_and_force: bool = True,
     ) -> AwaitableAction:
         """
         Move the gripper to a certain position at a certain speed with a certain force. This function is assumed to run
@@ -212,8 +211,8 @@ class SchunkEGK40_USB(ParallelPositionGripper):
         :param width_difference: in m,  a positive difference will make the gripper open, a negative difference makes it close
         :param speed: in m/s
         :param force: in N
-        :param set_speed_and_force: setting to false can improve control frequency as less transactions have to happen 
-        with the gripper. The reason to do this with an extra argument is so that the speed and force settings are 
+        :param set_speed_and_force: setting to false can improve control frequency as less transactions have to happen
+        with the gripper. The reason to do this with an extra argument is so that the speed and force settings are
         minimal by default, which is desirable for the strong Schunk gripper.
         """
         if set_speed_and_force:

--- a/airo-robots/setup.py
+++ b/airo-robots/setup.py
@@ -10,7 +10,7 @@ setuptools.setup(
     author="Thomas Lips",
     author_email="thomas.lips@ugent.be",
     install_requires=[
-        "numpy",
+        "numpy<2.0",
         "ur-rtde>=1.5.7",  # cf https://github.com/airo-ugent/airo-mono/issues/52
         "click",
         "airo-typing",

--- a/airo-spatial-algebra/setup.py
+++ b/airo-spatial-algebra/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     description="code for working with SE3 poses,transforms,... for robotic manipulation at the Ghent University AI and Robotics Lab",
     author="Thomas Lips",
     author_email="thomas.lips@ugent.be",
-    install_requires=["numpy", "scipy", "spatialmath-python", "airo-typing"],
+    install_requires=["numpy<2.0", "scipy", "spatialmath-python", "airo-typing"],
     packages=setuptools.find_packages(exclude=["test"]),
     # include py.typed to declare type information is available, see
     # https://mypy.readthedocs.io/en/stable/installed_packages.html#making-pep-561-compatible-packages

--- a/airo-typing/setup.py
+++ b/airo-typing/setup.py
@@ -6,7 +6,7 @@ setuptools.setup(
     description="python type definitions for use in the python packages at the Ghent University AI and Robotics Lab",
     author="Thomas Lips",
     author_email="thomas.lips@ugent.be",
-    install_requires=["numpy"],
+    install_requires=["numpy<2.0"],
     packages=setuptools.find_packages(exclude=["test"]),
     package_data={"airo_typing": ["py.typed"]},
 )

--- a/mypy.ini
+++ b/mypy.ini
@@ -64,3 +64,7 @@ ignore_missing_imports=True
 ignore_missing_imports=True
 [mypy-open3d.*]
 ignore_missing_imports=True
+[mypy-pyschunk.*]
+ignore_missing_imports=True
+[mypy-bkstools.*]
+ignore_missing_imports=True


### PR DESCRIPTION
## Describe your changes

Locks `numpy < 2.0` for all packages, because our OpenCV version was incompatible with newer NumPy versions.

See, e.g., this workflow run: https://github.com/airo-ugent/airo-mono/actions/runs/13111963494/job/36577677885

## Checklist
- [x] Have you modified the changelog?

