### PR TITLE
Fix CI failures

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -11,6 +11,6 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: 3.9
-    - uses: pre-commit/action@v2.0.3
+    - uses: pre-commit/action@v3.0.1
       with:
         extra_args: --all-files --hook-stage manual


### PR DESCRIPTION
GitHub decommissioned their old cache service on April 15th: https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts

We were using `pre-commit/action@v2.0.3` which depends on this old cache.

This PR updates it to `v3.0.1` (the most recent version) which should fix our CI.