### PR TITLE
opencv dependency fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This project uses a [CalVer](https://calver.org/) versioning scheme with monthly
 - Added easier imports for airo-camera-toolkit cameras. Now, instead of `from airo_camera_toolkit.cameras.opencv_videocapture.opencv_videocapture import OpenCVVideoCapture` you can just write `from airo_camera_toolkit.cameras import OpenCVVideoCapture`. Based on [PEP 562](https://peps.python.org/pep-0562/). Fixes the old issue [#122](https://github.com/airo-ugent/airo-mono/issues/122).
 
 ### Changed
+- `airo-camera-toolkit`: migrated aruco detection to the new OpenCV 4.8+ API (`ArucoDetector`, `CharucoDetector`, `solvePnP`) — the legacy `detectMarkers` / `interpolateCornersCharuco` / `estimatePoseSingleMarkers` functions were only present in `opencv-contrib-python` and absent when `opencv-python-headless` (pulled in by fiftyone) overwrote the `cv2` module.
+- `airo-dataset-tools`: moved `fiftyone` from a default dependency to an optional one (`pip install airo-dataset-tools[fiftyone]`). `fiftyone` installs `opencv-python-headless`, which conflicts with `opencv-contrib-python` by overwriting the `cv2` module. See the [README](airo-dataset-tools/README.md#fiftyone-installation) for the recommended install procedure.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project uses a [CalVer](https://calver.org/) versioning scheme with monthly
 ## Unreleased
 
 ### Breaking changes
+- `airo-dataset-tools`: `fiftyone` is no longer installed by default. Use `pip install "airo-dataset-tools[fiftyone]"` to include it. See the [README](airo-dataset-tools/README.md#fiftyone-installation) for details.
 
 ### Added
 - `airo-dataset-tools`: `merge_coco_datasets` now supports nested image subdirectories — images are copied to the target preserving their relative directory structure.
@@ -17,7 +18,6 @@ This project uses a [CalVer](https://calver.org/) versioning scheme with monthly
 
 ### Changed
 - `airo-camera-toolkit`: migrated aruco detection to the new OpenCV 4.8+ API (`ArucoDetector`, `CharucoDetector`, `solvePnP`) — the legacy `detectMarkers` / `interpolateCornersCharuco` / `estimatePoseSingleMarkers` functions were only present in `opencv-contrib-python` and absent when `opencv-python-headless` (pulled in by fiftyone) overwrote the `cv2` module.
-- `airo-dataset-tools`: moved `fiftyone` from a default dependency to an optional one (`pip install airo-dataset-tools[fiftyone]`). `fiftyone` installs `opencv-python-headless`, which conflicts with `opencv-contrib-python` by overwriting the `cv2` module. See the [README](airo-dataset-tools/README.md#fiftyone-installation) for the recommended install procedure.
 
 ### Fixed
 

--- a/airo-camera-toolkit/airo_camera_toolkit/calibration/fiducial_markers.py
+++ b/airo-camera-toolkit/airo_camera_toolkit/calibration/fiducial_markers.py
@@ -100,9 +100,10 @@ def get_poses_of_aruco_markers(
     half = marker_size / 2
     obj_points = np.array([[-half, half, 0], [half, half, 0], [half, -half, 0], [-half, -half, 0]], dtype=np.float32)
 
+    _dist = dist_coeffs if dist_coeffs is not None else np.zeros((4, 1), dtype=np.float32)
     marker_poses_in_camera_frame = []
     for corner in markers_detection_result.corners:
-        success, rvec, tvec = cv2.solvePnP(obj_points, corner[0], camera_matrix, dist_coeffs)  # type: ignore[arg-type]  # dist_coeffs may be None, which OpenCV accepts
+        success, rvec, tvec = cv2.solvePnP(obj_points, corner[0], camera_matrix, _dist)
         if not success:
             continue
         pose = SE3Container.from_rotation_vector_and_translation(rvec.flatten(), tvec.flatten()).homogeneous_matrix
@@ -132,10 +133,8 @@ def get_pose_of_charuco_board(
     if obj_points is None or img_points is None:
         return None
 
-    # Use solvePnP for pose estimation
-    success, rvec, tvec = cv2.solvePnP(
-        obj_points, img_points, camera_matrix, dist_coeffs  # type: ignore[arg-type]  # dist_coeffs may be None, which OpenCV accepts
-    )
+    _dist = dist_coeffs if dist_coeffs is not None else np.zeros((4, 1), dtype=np.float32)
+    success, rvec, tvec = cv2.solvePnP(obj_points, img_points, camera_matrix, _dist)
     if (rvec is None and tvec is None) or not success:
         return None
     # combine the rvec and tvec into a single pose matrix

--- a/airo-camera-toolkit/airo_camera_toolkit/calibration/fiducial_markers.py
+++ b/airo-camera-toolkit/airo_camera_toolkit/calibration/fiducial_markers.py
@@ -102,7 +102,7 @@ def get_poses_of_aruco_markers(
 
     marker_poses_in_camera_frame = []
     for corner in markers_detection_result.corners:
-        success, rvec, tvec = cv2.solvePnP(obj_points, corner[0], camera_matrix, dist_coeffs)
+        success, rvec, tvec = cv2.solvePnP(obj_points, corner[0], camera_matrix, dist_coeffs)  # type: ignore[arg-type]  # dist_coeffs may be None, which OpenCV accepts
         if not success:
             continue
         pose = SE3Container.from_rotation_vector_and_translation(rvec.flatten(), tvec.flatten()).homogeneous_matrix

--- a/airo-camera-toolkit/airo_camera_toolkit/calibration/fiducial_markers.py
+++ b/airo-camera-toolkit/airo_camera_toolkit/calibration/fiducial_markers.py
@@ -44,8 +44,9 @@ class CharucoCornerDetectionResult(ArucoMarkerDetectionResult):
 
 def detect_aruco_markers(image: OpenCVIntImageType, dictionary: ArucoDictType) -> Optional[ArucoMarkerDetectionResult]:
     """Detect markers from `aruco_dict` dictionary in the `image`."""
-    marker_corners, marker_ids, _ = aruco.detectMarkers(image, dictionary)
-    if marker_corners is None or marker_ids is None:
+    detector = aruco.ArucoDetector(dictionary)
+    marker_corners, marker_ids, _ = detector.detectMarkers(image)
+    if not marker_corners or marker_ids is None:
         return None
     marker_corners_array = np.stack(marker_corners)
     marker_corners_array = refine_corner_detection(image, marker_corners_array)
@@ -59,12 +60,8 @@ def detect_charuco_corners(
     charuco_board: CharucoBoardType,
 ) -> Optional[CharucoCornerDetectionResult]:
     """Detect CharuCo corners in the image using the detected markers in `markers_detection_result`."""
-    nb_corners, charuco_corners, charuco_ids = aruco.interpolateCornersCharuco(
-        markerCorners=markers_detection_result.corners,  # type: ignore # typed as Seq but accepts np.ndarray
-        markerIds=markers_detection_result.ids,
-        image=image,
-        board=charuco_board,
-    )
+    charuco_detector = aruco.CharucoDetector(charuco_board)
+    charuco_corners, charuco_ids, _, _ = charuco_detector.detectBoard(image)
     if charuco_corners is None or charuco_ids is None:
         return None
     charuco_corners = refine_corner_detection(image, charuco_corners)
@@ -99,23 +96,19 @@ def get_poses_of_aruco_markers(
     dist_coeffs: Optional[np.ndarray] = None,
 ) -> Optional[List[HomogeneousMatrixType]]:
     """Get the poses of the detected markers in `markers_detection_result`."""
-    rvecs, tvecs, _ = aruco.estimatePoseSingleMarkers(
-        corners=markers_detection_result.corners,  # type: ignore # typed as Seq but accepts np.ndarray
-        markerLength=marker_size,
-        cameraMatrix=camera_matrix,
-        distCoeffs=dist_coeffs,
-    )
-    if rvecs is None or tvecs is None:
-        return None
-    elif rvecs.shape != tvecs.shape:
-        raise ValueError("rvecs and tvecs should have the same shape. Do you have multiple markers with the same ID?")
+    # Object points for a single marker (top-left, top-right, bottom-right, bottom-left)
+    half = marker_size / 2
+    obj_points = np.array([[-half, half, 0], [half, half, 0], [half, -half, 0], [-half, -half, 0]], dtype=np.float32)
 
-    # combine the rvecs and tvecs into a single pose matrix
-    marker_poses_in_camera_frame = [
-        SE3Container.from_rotation_vector_and_translation(rvec[0], tvec).homogeneous_matrix
-        for rvec, tvec in zip(rvecs, tvecs)
-    ]
-    return marker_poses_in_camera_frame
+    marker_poses_in_camera_frame = []
+    for corner in markers_detection_result.corners:
+        success, rvec, tvec = cv2.solvePnP(obj_points, corner[0], camera_matrix, dist_coeffs)
+        if not success:
+            continue
+        pose = SE3Container.from_rotation_vector_and_translation(rvec.flatten(), tvec.flatten()).homogeneous_matrix
+        marker_poses_in_camera_frame.append(pose)
+
+    return marker_poses_in_camera_frame if marker_poses_in_camera_frame else None
 
 
 def get_pose_of_charuco_board(

--- a/airo-camera-toolkit/setup.py
+++ b/airo-camera-toolkit/setup.py
@@ -11,8 +11,7 @@ setuptools.setup(
     author_email="thomas.lips@ugent.be",
     install_requires=[
         "numpy>=2.0",
-        "opencv-contrib-python==4.10.0.84",  # We need opencv contrib for the aruco marker detection, but when some packages install (a different version of) opencv-python-headless, this breaks the contrib version. So we install both here to make sure they are the same version.
-        "opencv-python-headless==4.10.0.84",  # Lock to match contrib version.
+        "opencv-contrib-python==4.10.0.84",  # contrib required for cv2.ximgproc (stereo disparity) and GUI functions (cv2.imshow)
         "matplotlib",
         "rerun-sdk>=0.23.4",
         "click",

--- a/airo-dataset-tools/README.md
+++ b/airo-dataset-tools/README.md
@@ -4,7 +4,7 @@ They fall into two categories:
 
 [**COCO related tools**](airo_dataset_tools/coco_tools/README.md):
 * COCO dataset loading (and creation)
-* FiftyOne visualisation
+* FiftyOne visualisation (optional, see [installation note](#fiftyone-installation))
 * Albumentation transforms
 * COCO  to YOLO conversion.
 * CVAT labeling workflow
@@ -13,6 +13,19 @@ They fall into two categories:
 * 3D poses
 * Camera instrinsics
 
+
+## FiftyOne installation
+
+FiftyOne is an optional dependency. Install it with:
+
+```bash
+pip install "airo-dataset-tools[fiftyone]"
+```
+
+> **Note:** FiftyOne installs `opencv-python-headless`, which conflicts with `opencv-contrib-python` (both write to the same `cv2` namespace). To ensure the contrib build takes precedence, reinstall it after:
+> ```bash
+> pip install --force-reinstall opencv-contrib-python==4.10.0.84
+> ```
 
 > [Pydantic](https://docs.pydantic.dev/latest/) is used heavily throughout this package.
 It allows you to easily create Python objects that can be saved and loaded to and from JSON files.

--- a/airo-dataset-tools/airo_dataset_tools/coco_tools/README.md
+++ b/airo-dataset-tools/airo_dataset_tools/coco_tools/README.md
@@ -7,7 +7,7 @@ Overview of the functionality:
 * [COCO](#dataset-loading) dataset loading
 * COCO dataset creation (e.g. with synthetic data or CVAT)
 * [CVAT labeling workflow](../../airo_dataset_tools/cvat_labeling/readme.md)
-* FiftyOne visualisation (see CLI)
+* FiftyOne visualisation (see CLI, requires the `[fiftyone]` extra — see [installation note](../../README.md#fiftyone-installation))
 * Applying Albumentation transforms (e.g. resizing, flipping,...) to a COCO Keypoints dataset and its annotations, see [transform_dataset.py](transform_dataset.py)
 * Converting COCO instances to YOLO format, see [coco_instances_to_yolo.py](coco_instances_to_yolo.py)
 

--- a/airo-dataset-tools/setup.py
+++ b/airo-dataset-tools/setup.py
@@ -12,8 +12,7 @@ setuptools.setup(
     install_requires=[
         "numpy>=2.0",
         "pydantic>2.0.0",  # pydantic 2.0.0 has a lot of breaking changes
-        "opencv-contrib-python==4.10.0.84",  # See airo-camera-toolkit setup.py for explanation
-        "opencv-python-headless==4.10.0.84",  # See airo-camera-toolkit setup.py for explanation
+        "opencv-contrib-python==4.10.0.84",  # fiftyone installs opencv-python-headless; contrib must be listed to take precedence
         "pycocotools",
         "xmltodict",
         "tqdm",

--- a/airo-dataset-tools/setup.py
+++ b/airo-dataset-tools/setup.py
@@ -12,11 +12,14 @@ setuptools.setup(
     install_requires=[
         "numpy>=2.0",
         "pydantic>2.0.0",  # pydantic 2.0.0 has a lot of breaking changes
-        "opencv-contrib-python==4.10.0.84",  # fiftyone installs opencv-python-headless; contrib must be listed to take precedence
+        # opencv-contrib-python and opencv-python-headless both install a cv2 module and conflict
+        # with each other — whichever is installed last wins. fiftyone (in the [fiftyone] extra)
+        # pulls in opencv-python-headless. To ensure contrib wins after installing the extra, run:
+        #   pip install --force-reinstall opencv-contrib-python==4.10.0.84
+        "opencv-contrib-python==4.10.0.84",
         "pycocotools",
         "xmltodict",
         "tqdm",
-        "fiftyone",  # visualization
         "Pillow",
         "types-Pillow",
         "albumentations",
@@ -24,6 +27,9 @@ setuptools.setup(
         "airo-typing>=2026.1.0",
         "airo-spatial-algebra>=2026.1.0",
     ],
+    extras_require={
+        "fiftyone": ["fiftyone"],
+    },
     packages=setuptools.find_packages(exclude=["test"]),
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Both airo-camera-toolkit and airo-dataset-tools (via fiftyone) installed opencv-python-headless alongside opencv-contrib-python. 
The reason for this is that fiftyone installs headless, so we tried to lock versions by installing it ourselves first.

Since both packages write to the same cv2 namespace, whichever is installed last wins — causing non-deterministic test failures when headless overwrote contrib's cv2. So this fix introduced a new problem.

**solution**
1) limit usage of contrib-only API.
The legacy aruco functions (detectMarkers, interpolateCornersCharuco, estimatePoseSingleMarkers) are only present in the contrib build. The new API (ArucoDetector, CharucoDetector, solvePnP) is part of core opencv and works with either headless or contrib. So this PR switches to those.

2) avoid issue in default install by making fiftyone optional.

Remaining contrib dependencies:
- cv2.ximgproc (stereo disparity WLS filter): interfaces.py, realsense.py
- cv2.imshow / cv2.namedWindow / cv2.waitKey (GUI): various interactive scripts

These might fail if the fiftyone install has caused headless to be installed over the contrib version. There is no elegant solution for this? If it happens, the user has to manually install contrib again: 
``` pip install --force-reinstall opencv-contrib-python-XX```
Therefore, I have moved fiftyone to extras_require with a comment in the docstring about this.




## Checklist
- [x] Have you modified the changelog?
- [ ] If you made changes to the hardware interfaces, have you tested them using the manual tests?
