### PR TITLE
Move albumentations to optional [augmentations] extra in airo-dataset

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -34,6 +34,7 @@ jobs:
         pip install wheel setuptools
         pip install "pytest<8.0.0"
         pip install airo-typing/ airo-spatial-algebra/ airo-camera-toolkit/ airo-robots/ "airo-dataset-tools/[augmentations]"
+        pip install --force-reinstall opencv-contrib-python==4.10.0.84
     - name: Run Tests
       run: pytest ${{matrix.package}}/
     - name: Run Notebooks

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -33,7 +33,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install wheel setuptools
         pip install "pytest<8.0.0"
-        pip install airo-typing/ airo-spatial-algebra/ airo-camera-toolkit/ airo-robots/ airo-dataset-tools/
+        pip install airo-typing/ airo-spatial-algebra/ airo-camera-toolkit/ airo-robots/ "airo-dataset-tools/[augmentations]"
     - name: Run Tests
       run: pytest ${{matrix.package}}/
     - name: Run Notebooks

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -34,7 +34,11 @@ jobs:
         pip install wheel setuptools
         pip install "pytest<8.0.0"
         pip install airo-typing/ airo-spatial-algebra/ airo-camera-toolkit/ airo-robots/ "airo-dataset-tools/[augmentations]"
-        pip install --force-reinstall opencv-contrib-python==4.10.0.84
+        # albumentations (via [augmentations]) and fiftyone (via [fiftyone]) both pull in
+        # opencv-python-headless, which conflicts with opencv-contrib-python — whichever is
+        # installed last overwrites the cv2 namespace. Force-reinstall contrib so it wins.
+        OPENCV_VERSION=$(grep -oP 'opencv-contrib-python==\K[^\s"]+' airo-dataset-tools/setup.py)
+        pip install --force-reinstall "opencv-contrib-python==$OPENCV_VERSION"
     - name: Run Tests
       run: pytest ${{matrix.package}}/
     - name: Run Notebooks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project uses a [CalVer](https://calver.org/) versioning scheme with monthly
 
 ### Breaking changes
 - `airo-dataset-tools`: `fiftyone` is no longer installed by default. Use `pip install "airo-dataset-tools[fiftyone]"` to include it. See the [README](airo-dataset-tools/README.md#fiftyone-installation) for details.
+- `airo-dataset-tools`: `albumentations` is no longer installed by default. Use `pip install "airo-dataset-tools[augmentations]"` to include it. See the [README](airo-dataset-tools/README.md#augmentations-installation) for details.
 
 ### Added
 - `airo-dataset-tools`: `merge_coco_datasets` now supports nested image subdirectories — images are copied to the target preserving their relative directory structure.

--- a/airo-dataset-tools/README.md
+++ b/airo-dataset-tools/README.md
@@ -5,7 +5,7 @@ They fall into two categories:
 [**COCO related tools**](airo_dataset_tools/coco_tools/README.md):
 * COCO dataset loading (and creation)
 * FiftyOne visualisation (optional, see [installation note](#fiftyone-installation))
-* Albumentation transforms
+* Albumentations transforms (optional, see [installation note](#augmentations-installation))
 * COCO  to YOLO conversion.
 * CVAT labeling workflow
 
@@ -13,6 +13,19 @@ They fall into two categories:
 * 3D poses
 * Camera instrinsics
 
+
+## Augmentations installation
+
+Albumentations (used for COCO dataset transforms) is an optional dependency. Install it with:
+
+```bash
+pip install "airo-dataset-tools[augmentations]"
+```
+
+> **Note:** `albumentations` installs `opencv-python-headless`, which conflicts with `opencv-contrib-python` (both write to the same `cv2` namespace). To ensure the contrib build takes precedence, reinstall it after:
+> ```bash
+> pip install --force-reinstall opencv-contrib-python==4.10.0.84
+> ```
 
 ## FiftyOne installation
 

--- a/airo-dataset-tools/airo_dataset_tools/coco_tools/transform_dataset.py
+++ b/airo-dataset-tools/airo_dataset_tools/coco_tools/transform_dataset.py
@@ -2,7 +2,13 @@ import json
 import os
 from typing import Any, Callable, List, Optional
 
-import albumentations as A
+try:
+    import albumentations as A
+except ImportError as e:
+    raise ImportError(
+        "albumentations is required for this module. Install it with: "
+        'pip install "airo-dataset-tools[augmentations]"'
+    ) from e
 import cv2
 import numpy as np
 import tqdm

--- a/airo-dataset-tools/airo_dataset_tools/coco_tools/transforms.py
+++ b/airo-dataset-tools/airo_dataset_tools/coco_tools/transforms.py
@@ -1,6 +1,12 @@
 from typing import Any
 
-import albumentations as A
+try:
+    import albumentations as A
+except ImportError as e:
+    raise ImportError(
+        "albumentations is required for this module. Install it with: "
+        'pip install "airo-dataset-tools[augmentations]"'
+    ) from e
 import numpy as np
 from PIL import Image
 

--- a/airo-dataset-tools/setup.py
+++ b/airo-dataset-tools/setup.py
@@ -13,8 +13,9 @@ setuptools.setup(
         "numpy>=2.0",
         "pydantic>2.0.0",  # pydantic 2.0.0 has a lot of breaking changes
         # opencv-contrib-python and opencv-python-headless both install a cv2 module and conflict
-        # with each other — whichever is installed last wins. fiftyone (in the [fiftyone] extra)
-        # pulls in opencv-python-headless. To ensure contrib wins after installing the extra, run:
+        # with each other — whichever is installed last wins. Both fiftyone (in the [fiftyone]
+        # extra) and albumentations (in the [augmentations] extra) pull in opencv-python-headless.
+        # To ensure contrib wins after installing either extra, run:
         #   pip install --force-reinstall opencv-contrib-python==4.10.0.84
         "opencv-contrib-python==4.10.0.84",
         "pycocotools",
@@ -22,12 +23,12 @@ setuptools.setup(
         "tqdm",
         "Pillow",
         "types-Pillow",
-        "albumentations",
         "click",
         "airo-typing>=2026.1.0",
         "airo-spatial-algebra>=2026.1.0",
     ],
     extras_require={
+        "augmentations": ["albumentations"],
         "fiftyone": ["fiftyone"],
     },
     packages=setuptools.find_packages(exclude=["test"]),


### PR DESCRIPTION

albumentations (and its dep albucore) pull in opencv-python-headless, which conflicts with opencv-contrib-python. Making it optional prevents the conflict for users who don't need COCO dataset transforms.

## Describe your changes


## Checklist
- [x] Have you modified the changelog?
- [ ] If you made changes to the hardware interfaces, have you tested them using the manual tests?
