### PR TITLE
Replace airo-ipc with Zenoh in multiprocess camera IPC

### DIFF
--- a/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/README.md
+++ b/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/README.md
@@ -12,7 +12,7 @@ There a few things that make this difficult:
 * We also might want to log, visualize, save images or videos.
 * Parallellism in a [single Python process is tricky due to the GIL](https://stackoverflow.com/questions/18114285/what-are-the-differences-between-the-threading-and-multiprocessing-modules).
 
-To overcome these difficulties we used [airo-ipc](https://github.com/airo-ugent/airo-ipc) to create a solution where:
+To overcome these difficulties we use [Zenoh](https://zenoh.io/) to create a solution where:
 * Camera images can be retrieved, visualized, recorded, etc. without being blocked by user code (e.g. robot commands)
 * Robot commands can be sent at high frequency without having to retrieve images inbetween
 

--- a/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/base_publisher.py
+++ b/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/base_publisher.py
@@ -6,11 +6,19 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 import numpy as np
+import zenoh
 from airo_camera_toolkit.cameras.multiprocess.frame_data import FpsIdl, ResolutionIdl
+from airo_camera_toolkit.cameras.multiprocess.zenoh_writer import ZenohWriter
 from airo_camera_toolkit.interfaces import RGBCamera
-from airo_ipc.cyclone_shm.patterns.sm_writer import SMWriter
-from cyclonedds.domain import DomainParticipant
 from loguru import logger
+
+
+def _make_zenoh_config(shm: bool = True) -> zenoh.Config:
+    """Return a Zenoh configuration with shared memory transport optionally enabled."""
+    conf = zenoh.Config()
+    if shm:
+        conf.insert_json5("transport/shared_memory/enabled", "true")
+    return conf
 
 
 class BaseCameraPublisher(multiprocessing.context.Process, ABC):
@@ -45,18 +53,17 @@ class BaseCameraPublisher(multiprocessing.context.Process, ABC):
         self._frame_id = 0
 
     def _setup(self) -> None:
-        """Initialize the camera and shared memory infrastructure.
+        """Initialize the camera and Zenoh publishing infrastructure.
 
         Note: Camera must be instantiated in the publisher process to retrieve images.
         """
-        # Initialize DDS domain participant
-        self._dp = DomainParticipant()
-        self._resolution_writer = SMWriter(
-            self._dp,
+        self._session = zenoh.open(_make_zenoh_config())
+        self._resolution_writer = ZenohWriter(
+            self._session,
             f"{self._shared_memory_namespace}_resolution",
             ResolutionIdl.template(),
         )
-        self._fps_writer = SMWriter(self._dp, f"{self._shared_memory_namespace}_fps", FpsIdl.template())
+        self._fps_writer = ZenohWriter(self._session, f"{self._shared_memory_namespace}_fps", FpsIdl.template())
 
         # Instantiate the camera
         logger.info(f"Instantiating a {self._camera_cls.__name__} camera.")
@@ -67,17 +74,17 @@ class BaseCameraPublisher(multiprocessing.context.Process, ABC):
 
         logger.info(f"Successfully instantiated a {self._camera_cls.__name__} camera.")
 
-        # Set up shared memory writers
+        # Set up frame writer
         self._setup_frame_writer()
 
     def _setup_frame_writer(self) -> None:
         """Set up the main frame data writer."""
         frame_buffer_template = self._get_frame_buffer_template(self._camera.resolution[0], self._camera.resolution[1])
 
-        self._writer = SMWriter(
-            domain_participant=self._dp,
-            topic_name=self._shared_memory_namespace,
-            idl_dataclass=frame_buffer_template,
+        self._writer = ZenohWriter(
+            session=self._session,
+            key_expr=self._shared_memory_namespace,
+            template=frame_buffer_template,
         )
 
     def _publish_metadata(self) -> None:
@@ -125,6 +132,7 @@ class BaseCameraPublisher(multiprocessing.context.Process, ABC):
             logger.error(f"Error in {self.__class__.__name__}: {e}")
             raise
         finally:
+            self._session.close()
             logger.info(f"{self.__class__.__name__} process terminated.")
 
     @abstractmethod

--- a/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/base_receiver.py
+++ b/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/base_receiver.py
@@ -4,11 +4,12 @@ import time
 from abc import ABC, abstractmethod
 from typing import Any
 
+import zenoh
+from airo_camera_toolkit.cameras.multiprocess.base_publisher import _make_zenoh_config
 from airo_camera_toolkit.cameras.multiprocess.frame_data import FpsIdl, ResolutionIdl
+from airo_camera_toolkit.cameras.multiprocess.zenoh_reader import ZenohReader
 from airo_camera_toolkit.interfaces import RGBCamera
-from airo_ipc.cyclone_shm.patterns.sm_reader import SMReader
 from airo_typing import CameraResolutionType
-from cyclonedds.domain import DomainParticipant
 from loguru import logger
 
 
@@ -31,8 +32,8 @@ class BaseCameraReceiver(RGBCamera, ABC):
         self._shared_memory_namespace = shared_memory_namespace
         self._block_until_new_frame = block_until_new_frame
 
-        # Initialize the DDS domain participant
-        self._dp = DomainParticipant()
+        # Open a Zenoh session for receiving
+        self._session = zenoh.open(_make_zenoh_config())
 
         # Read static camera information
         self._resolution = self._read_resolution(shared_memory_namespace)
@@ -48,10 +49,10 @@ class BaseCameraReceiver(RGBCamera, ABC):
         """Set up the main frame data reader."""
         frame_buffer_template = self._get_frame_buffer_template(resolution[0], resolution[1])
 
-        self._reader = SMReader(
-            domain_participant=self._dp,
-            topic_name=self._shared_memory_namespace,
-            idl_dataclass=frame_buffer_template,
+        self._reader = ZenohReader(
+            session=self._session,
+            key_expr=self._shared_memory_namespace,
+            template=frame_buffer_template,
         )
 
         # Initialize an empty frame
@@ -67,8 +68,9 @@ class BaseCameraReceiver(RGBCamera, ABC):
     def _read_fps(self, shared_memory_namespace: str) -> int:
         """Read the camera FPS from shared memory."""
         logger.info(f"Reading FPS from {shared_memory_namespace}_fps")
-        fps_reader = SMReader(self._dp, f"{shared_memory_namespace}_fps", FpsIdl.template())
+        fps_reader = ZenohReader(self._session, f"{shared_memory_namespace}_fps", FpsIdl.template())
         fps_data = fps_reader()
+        fps_reader.stop()
         assert isinstance(fps_data, FpsIdl)  # for mypy
         fps = int(fps_data.fps.item())
         logger.info(f"Camera FPS: {fps}")
@@ -77,8 +79,11 @@ class BaseCameraReceiver(RGBCamera, ABC):
     def _read_resolution(self, shared_memory_namespace: str) -> CameraResolutionType:
         """Read the camera resolution from shared memory."""
         logger.info(f"Reading resolution from {shared_memory_namespace}_resolution")
-        resolution_reader = SMReader(self._dp, f"{shared_memory_namespace}_resolution", ResolutionIdl.template())
+        resolution_reader = ZenohReader(
+            self._session, f"{shared_memory_namespace}_resolution", ResolutionIdl.template()
+        )
         resolution_data = resolution_reader()
+        resolution_reader.stop()
         assert isinstance(resolution_data, ResolutionIdl)  # for mypy
         resolution = (
             int(resolution_data.resolution[0]),

--- a/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/base_receiver.py
+++ b/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/base_receiver.py
@@ -112,18 +112,13 @@ class BaseCameraReceiver(RGBCamera, ABC):
 
     def grab_images(self) -> None:
         """Read the latest frame from shared memory."""
-        previous_timestamp = self._last_frame.frame_timestamp.item()
-
-        # Block until we get a frame with a newer timestamp
+        # Block until a new message arrives (compare frame counter, not timestamp).
+        # This avoids the expensive deserialization on every poll iteration.
         if self._block_until_new_frame:
-            while True:
-                self._last_frame = self._reader()
-                current_timestamp = self._last_frame.frame_timestamp.item()
-                if current_timestamp > previous_timestamp:
-                    break
-                time.sleep(0.001)  # Sleep briefly to avoid busy waiting
-        else:
-            self._last_frame = self._reader()
+            previous_count = self._reader.frame_count
+            while self._reader.frame_count == previous_count:
+                time.sleep(0.001)
+        self._last_frame = self._reader()
 
     @abstractmethod
     def _get_frame_buffer_template(self, width: int, height: int) -> Any:

--- a/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/frame_data.py
+++ b/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/frame_data.py
@@ -16,7 +16,10 @@ def serialize_frame(obj: Any) -> bytes:
     The schema (field order, shapes, dtypes) must be agreed upon by both sides
     via the corresponding ``template()`` classmethod.
     """
-    return b"".join(getattr(obj, f.name).tobytes() for f in dataclasses.fields(obj))
+    parts = [getattr(obj, f.name).ravel().view(np.uint8) for f in dataclasses.fields(obj)]
+    flat = np.empty(sum(p.nbytes for p in parts), dtype=np.uint8)
+    np.concatenate(parts, out=flat)
+    return bytes(flat)
 
 
 def deserialize_frame(template: T, data: bytes) -> T:

--- a/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/frame_data.py
+++ b/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/frame_data.py
@@ -1,38 +1,71 @@
-"""Data structures for frame buffers sent over shared memory."""
+"""Data structures for frame buffers used with Zenoh IPC."""
 
+import dataclasses
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, TypeVar
 
 import numpy as np
-from airo_ipc.cyclone_shm.idl_shared_memory.base_idl import BaseIdl
+
+T = TypeVar("T")
+
+
+def serialize_frame(obj: Any) -> bytes:
+    """Serialize a frame buffer dataclass to raw bytes.
+
+    All numpy fields are concatenated in dataclass field declaration order.
+    The schema (field order, shapes, dtypes) must be agreed upon by both sides
+    via the corresponding ``template()`` classmethod.
+    """
+    return b"".join(getattr(obj, f.name).tobytes() for f in dataclasses.fields(obj))
+
+
+def deserialize_frame(template: T, data: bytes) -> T:
+    """Deserialize raw bytes back into a frame buffer dataclass instance.
+
+    Args:
+        template: A template instance (from ``FrameBuffer.template()``) that
+            defines the expected field shapes and dtypes.
+        data: Raw bytes produced by :func:`serialize_frame`.
+
+    Returns:
+        A new dataclass instance with numpy arrays filled from ``data``.
+    """
+    kwargs: dict = {}
+    offset = 0
+    for f in dataclasses.fields(template):  # type: ignore[arg-type]
+        arr: np.ndarray = getattr(template, f.name)
+        chunk = data[offset : offset + arr.nbytes]
+        kwargs[f.name] = np.frombuffer(chunk, dtype=arr.dtype).reshape(arr.shape).copy()
+        offset += arr.nbytes
+    return template.__class__(**kwargs)  # type: ignore[return-value]
 
 
 @dataclass
-class FpsIdl(BaseIdl):
-    """This struct, sent over shared memory, contains the FPS of the camera."""
+class FpsIdl:
+    """Frame rate metadata published alongside camera frames."""
 
     fps: np.ndarray
 
     @staticmethod
     def template() -> Any:
-        """Construct a new FpsIdl with shared memory backed arrays."""
+        """Construct a new FpsIdl template with pre-allocated arrays."""
         return FpsIdl(fps=np.empty((1,), dtype=np.float64))
 
 
 @dataclass
-class ResolutionIdl(BaseIdl):
-    """This struct, sent over shared memory, contains the resolution of the camera."""
+class ResolutionIdl:
+    """Resolution metadata published alongside camera frames."""
 
     resolution: np.ndarray
 
     @staticmethod
     def template() -> Any:
-        """Construct a new ResolutionIdl with shared memory backed arrays."""
+        """Construct a new ResolutionIdl template with pre-allocated arrays."""
         return ResolutionIdl(resolution=np.empty((2,), dtype=np.int32))
 
 
 @dataclass
-class BaseFrameBuffer(BaseIdl):
+class BaseFrameBuffer:
     """Base frame buffer containing timestamp and frame ID for synchronization."""
 
     # Frame ID for synchronization (monotonically increasing)
@@ -192,7 +225,7 @@ class ZedFrameBuffer(StereoRGBDFrameBuffer):
 
 
 @dataclass
-class PointCloudBuffer(BaseIdl):
+class PointCloudBuffer:
     """Buffer containing point cloud data."""
 
     # Frame ID for synchronization
@@ -219,7 +252,7 @@ class PointCloudBuffer(BaseIdl):
 
 
 @dataclass
-class SpatialMapBuffer(BaseIdl):
+class SpatialMapBuffer:
     """Buffer containing spatial map data from Zed camera."""
 
     # Frame ID for synchronization

--- a/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/multiprocess_zed_camera.py
+++ b/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/multiprocess_zed_camera.py
@@ -9,10 +9,10 @@ import numpy as np
 from airo_camera_toolkit.cameras.multiprocess.base_publisher import BaseCameraPublisher
 from airo_camera_toolkit.cameras.multiprocess.frame_data import PointCloudBuffer, SpatialMapBuffer, ZedFrameBuffer
 from airo_camera_toolkit.cameras.multiprocess.multiprocess_stereo_rgbd_camera import MultiprocessStereoRGBDReceiver
+from airo_camera_toolkit.cameras.multiprocess.zenoh_reader import ZenohReader
+from airo_camera_toolkit.cameras.multiprocess.zenoh_writer import ZenohWriter
 from airo_camera_toolkit.cameras.zed.zed import Zed, ZedSpatialMap
 from airo_camera_toolkit.interfaces import StereoRGBDCamera
-from airo_ipc.cyclone_shm.patterns.sm_reader import SMReader
-from airo_ipc.cyclone_shm.patterns.sm_writer import SMWriter
 from airo_typing import CameraResolutionType, HomogeneousMatrixType, NumpyDepthMapType, NumpyIntImageType, PointCloud
 
 logger = loguru.logger
@@ -63,10 +63,10 @@ class MultiprocessZedPublisher(BaseCameraPublisher):
                 (self._camera.resolution[0] * self._camera.resolution[1], 3),
                 dtype=np.uint8,
             )
-            self._pcd_writer = SMWriter(
-                domain_participant=self._dp,
-                topic_name=f"{self._shared_memory_namespace}_pcd",
-                idl_dataclass=PointCloudBuffer.template(self._camera.resolution[0], self._camera.resolution[1]),
+            self._pcd_writer = ZenohWriter(
+                session=self._session,
+                key_expr=f"{self._shared_memory_namespace}_pcd",
+                template=PointCloudBuffer.template(self._camera.resolution[0], self._camera.resolution[1]),
             )
 
         if self.enable_spatial_mapping:
@@ -75,10 +75,10 @@ class MultiprocessZedPublisher(BaseCameraPublisher):
             self._spatial_map_chunk_sizes = np.zeros(self.max_spatial_map_chunks, dtype=np.int32)
             self._spatial_map_point_positions = np.zeros((self.max_spatial_map_points, 3), dtype=np.float32)
             self._spatial_map_point_colors = np.zeros((self.max_spatial_map_points, 3), dtype=np.uint8)
-            self._spatial_map_writer = SMWriter(
-                domain_participant=self._dp,
-                topic_name=f"{self._shared_memory_namespace}_spatial_map",
-                idl_dataclass=SpatialMapBuffer.template(self.max_spatial_map_chunks, self.max_spatial_map_points),
+            self._spatial_map_writer = ZenohWriter(
+                session=self._session,
+                key_expr=f"{self._shared_memory_namespace}_spatial_map",
+                template=SpatialMapBuffer.template(self.max_spatial_map_chunks, self.max_spatial_map_points),
             )
 
     def _retrieve_frame_data(self, frame_id: int, frame_timestamp: float) -> None:
@@ -224,18 +224,18 @@ class MultiprocessZedReceiver(MultiprocessStereoRGBDReceiver, StereoRGBDCamera):
         super()._setup_frame_reader(resolution)
 
         if self.enable_pointcloud:
-            self._reader_pcd = SMReader(
-                domain_participant=self._dp,
-                topic_name=f"{self._shared_memory_namespace}_pcd",
-                idl_dataclass=PointCloudBuffer.template(resolution[0], resolution[1]),
+            self._reader_pcd = ZenohReader(
+                session=self._session,
+                key_expr=f"{self._shared_memory_namespace}_pcd",
+                template=PointCloudBuffer.template(resolution[0], resolution[1]),
             )
             self._last_pcd_frame = PointCloudBuffer.template(resolution[0], resolution[1])
 
         if self.enable_spatial_mapping:
-            self._reader_spatial_map = SMReader(
-                domain_participant=self._dp,
-                topic_name=f"{self._shared_memory_namespace}_spatial_map",
-                idl_dataclass=SpatialMapBuffer.template(self.max_spatial_map_chunks, self.max_spatial_map_points),
+            self._reader_spatial_map = ZenohReader(
+                session=self._session,
+                key_expr=f"{self._shared_memory_namespace}_spatial_map",
+                template=SpatialMapBuffer.template(self.max_spatial_map_chunks, self.max_spatial_map_points),
             )
             self._last_spatial_map_frame = SpatialMapBuffer.template(
                 self.max_spatial_map_chunks, self.max_spatial_map_points

--- a/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/zenoh_reader.py
+++ b/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/zenoh_reader.py
@@ -1,0 +1,110 @@
+"""Zenoh-based reader for inter-process frame buffer communication."""
+
+import atexit
+import threading
+import time
+from typing import Any, Optional
+
+import zenoh
+from airo_camera_toolkit.cameras.multiprocess.frame_data import deserialize_frame
+from loguru import logger
+
+
+class WaitingForFirstMessageException(Exception):
+    """Raised when no data has been received yet."""
+
+
+class ZenohReader:
+    """Subscribes to a Zenoh key expression and deserializes the latest frame.
+
+    This is a drop-in replacement for ``airo_ipc``'s ``SMReader``.  The
+    subscriber callback runs in a Zenoh-managed background thread; a
+    :class:`threading.Lock` guards access to the latest received bytes so the
+    calling thread can safely call :meth:`__call__` at any time.
+
+    The constructor blocks until the first message arrives (mirroring
+    ``SMReader``'s ``__wait_for_writer`` behaviour).
+
+    Args:
+        session: An open :class:`zenoh.Session`.
+        key_expr: Zenoh key expression to subscribe to.
+        template: A template instance (from ``FrameBuffer.template()``) that
+            defines the expected field shapes and dtypes used for
+            deserialization.
+        timeout: Maximum seconds to wait for the first message.  ``None``
+            means wait indefinitely.
+        warn_every: Log a warning every this many seconds while waiting.
+    """
+
+    def __init__(
+        self,
+        session: zenoh.Session,
+        key_expr: str,
+        template: Any,
+        timeout: Optional[float] = None,
+        warn_every: int = 60,
+    ) -> None:
+        self._template = template
+        self._latest_bytes: Optional[bytes] = None
+        self._lock = threading.Lock()
+
+        self._subscriber = session.declare_subscriber(key_expr, self._callback)
+        self._wait_for_writer(key_expr, timeout=timeout, warn_every=warn_every)
+        atexit.register(self.stop)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+
+    def _callback(self, sample: zenoh.Sample) -> None:
+        with self._lock:
+            self._latest_bytes = bytes(sample.payload)
+
+    def _wait_for_writer(
+        self,
+        key_expr: str,
+        timeout: Optional[float],
+        warn_every: int,
+    ) -> None:
+        """Block until the first message is received."""
+        t0 = time.time()
+        warned = 0
+
+        while True:
+            with self._lock:
+                if self._latest_bytes is not None:
+                    return
+
+            elapsed = time.time() - t0
+
+            if timeout is not None and elapsed >= timeout:
+                raise RuntimeError(f"ZenohReader '{key_expr}' timed out after {timeout}s waiting for first message.")
+
+            if warn_every * (warned + 1) <= elapsed:
+                warned += 1
+                remaining = f"{timeout - elapsed:.0f}s remaining" if timeout is not None else "no timeout"
+                logger.warning(f"ZenohReader '{key_expr}' has been waiting for {warned * warn_every}s ({remaining}).")
+
+            time.sleep(0.01)
+
+    # ------------------------------------------------------------------
+    # Public API
+
+    def __call__(self) -> Any:
+        """Return the most recently received frame, deserialized from bytes.
+
+        Raises:
+            WaitingForFirstMessageException: If no data has been received yet
+                (should not happen after ``__init__`` returns).
+        """
+        with self._lock:
+            if self._latest_bytes is None:
+                raise WaitingForFirstMessageException("No data received yet — was the publisher started?")
+            return deserialize_frame(self._template, self._latest_bytes)
+
+    def stop(self) -> None:
+        """Undeclare the subscriber and release its resources."""
+        try:
+            self._subscriber.undeclare()
+        except Exception:
+            pass
+        atexit.unregister(self.stop)

--- a/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/zenoh_reader.py
+++ b/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/zenoh_reader.py
@@ -57,7 +57,7 @@ class ZenohReader:
 
     def _callback(self, sample: zenoh.Sample) -> None:
         with self._lock:
-            self._latest_bytes = bytes(sample.payload)
+            self._latest_bytes = sample.payload.to_bytes()
 
     def _wait_for_writer(
         self,

--- a/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/zenoh_reader.py
+++ b/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/zenoh_reader.py
@@ -46,18 +46,30 @@ class ZenohReader:
     ) -> None:
         self._template = template
         self._latest_bytes: Optional[bytes] = None
+        self._frame_count: int = 0
         self._lock = threading.Lock()
 
         self._subscriber = session.declare_subscriber(key_expr, self._callback)
         self._wait_for_writer(key_expr, timeout=timeout, warn_every=warn_every)
         atexit.register(self.stop)
 
+    @property
+    def frame_count(self) -> int:
+        """Number of messages received so far (monotonically increasing)."""
+        with self._lock:
+            return self._frame_count
+
     # ------------------------------------------------------------------
     # Internal helpers
 
     def _callback(self, sample: zenoh.Sample) -> None:
+        # Copy payload to local bytes BEFORE acquiring the lock.
+        # This keeps the lock acquisition brief and avoids blocking __call__
+        # while the SHM-to-bytes copy is in progress.
+        data = sample.payload.to_bytes()
         with self._lock:
-            self._latest_bytes = sample.payload.to_bytes()
+            self._latest_bytes = data
+            self._frame_count += 1
 
     def _wait_for_writer(
         self,
@@ -99,7 +111,10 @@ class ZenohReader:
         with self._lock:
             if self._latest_bytes is None:
                 raise WaitingForFirstMessageException("No data received yet — was the publisher started?")
-            return deserialize_frame(self._template, self._latest_bytes)
+            data = self._latest_bytes
+        # Deserialize outside the lock so the Zenoh callback can update
+        # _latest_bytes concurrently without blocking here.
+        return deserialize_frame(self._template, data)
 
     def stop(self) -> None:
         """Undeclare the subscriber and release its resources."""

--- a/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/zenoh_writer.py
+++ b/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/zenoh_writer.py
@@ -1,41 +1,76 @@
 """Zenoh-based writer for inter-process frame buffer communication."""
 
 import atexit
+import dataclasses
 from typing import Any
 
 import zenoh
-from airo_camera_toolkit.cameras.multiprocess.frame_data import serialize_frame
+from loguru import logger
+
+# Number of in-flight SHM frames to keep resident in the pool.
+# A larger pool means slow consumers are less likely to stall the publisher.
+_POOL_FRAMES = 32
+# Minimum SHM pool size regardless of frame size.
+_MIN_POOL_BYTES = 64 * 1024 * 1024  # 64 MB
 
 
 class ZenohWriter:
     """Publishes frame buffer dataclass instances over a Zenoh key expression.
 
-    This is a drop-in replacement for ``airo_ipc``'s ``SMWriter``.  The payload
-    is the concatenation of all numpy field bytes (see :func:`serialize_frame`).
-    With a Zenoh session configured to use SHM transport the bytes are placed
-    directly in shared memory, avoiding an extra copy between processes on the
-    same host.
+    Each frame is allocated from a :class:`zenoh.shm.ShmProvider` pool and
+    serialized into shared memory field-by-field.  The Zenoh transport then
+    hands the SHM reference to subscribers without an additional copy, giving
+    the same single-copy behaviour as ``airo_ipc``'s ``SMWriter``.
+
+    Per-field copying (``arr.tobytes()`` followed by a SHM slice assignment)
+    keeps each field's bytes hot in CPU cache between the two copies, which is
+    measurably faster than first concatenating everything into a flat buffer.
+
+    If the SHM pool is momentarily full (all buffers still in flight to slow
+    consumers) the frame is dropped and a warning is logged.  This matches
+    Zenoh's ``CongestionControl.DROP`` semantics used on the publisher.
 
     Args:
         session: An open :class:`zenoh.Session`.
         key_expr: Zenoh key expression (topic name) to publish on.
         template: A template instance (from ``FrameBuffer.template()``) whose
-            field layout defines the wire format.  Not used at runtime but kept
-            for symmetry with :class:`ZenohReader`.
+            field layout defines the wire format and the SHM pool allocation
+            size.
     """
 
     def __init__(self, session: zenoh.Session, key_expr: str, template: Any) -> None:
-        self._publisher = session.declare_publisher(key_expr)
-        self._template = template
+        self._field_names = [f.name for f in dataclasses.fields(template)]
+        self._frame_size = sum(getattr(template, name).nbytes for name in self._field_names)
+        pool_size = max(self._frame_size * _POOL_FRAMES, _MIN_POOL_BYTES)
+        self._provider = zenoh.shm.ShmProvider.default_backend(pool_size)
+        self._publisher = session.declare_publisher(
+            key_expr,
+            congestion_control=zenoh.CongestionControl.DROP,
+        )
+        self._key_expr = key_expr
         atexit.register(self.stop)
 
     def __call__(self, msg: Any) -> None:
-        """Serialize *msg* and publish it.
+        """Serialize *msg* into an SHM buffer and publish it.
+
+        Each numpy field is copied directly from the field's memory into the
+        SHM buffer, keeping it in CPU cache between the two operations.
 
         Args:
             msg: A frame buffer dataclass instance (same type as the template).
         """
-        self._publisher.put(serialize_frame(msg))
+        try:
+            buf = self._provider.alloc(self._frame_size, zenoh.shm.GarbageCollect())
+        except zenoh.ZError:
+            logger.warning(f"ZenohWriter: SHM pool full, dropping frame on '{self._key_expr}'")
+            return
+        offset = 0
+        for name in self._field_names:
+            field_bytes = getattr(msg, name).tobytes()
+            n = len(field_bytes)
+            buf[offset : offset + n] = field_bytes
+            offset += n
+        self._publisher.put(zenoh.ZBytes(buf))
 
     def stop(self) -> None:
         """Undeclare the publisher and release its resources."""

--- a/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/zenoh_writer.py
+++ b/airo-camera-toolkit/airo_camera_toolkit/cameras/multiprocess/zenoh_writer.py
@@ -1,0 +1,46 @@
+"""Zenoh-based writer for inter-process frame buffer communication."""
+
+import atexit
+from typing import Any
+
+import zenoh
+from airo_camera_toolkit.cameras.multiprocess.frame_data import serialize_frame
+
+
+class ZenohWriter:
+    """Publishes frame buffer dataclass instances over a Zenoh key expression.
+
+    This is a drop-in replacement for ``airo_ipc``'s ``SMWriter``.  The payload
+    is the concatenation of all numpy field bytes (see :func:`serialize_frame`).
+    With a Zenoh session configured to use SHM transport the bytes are placed
+    directly in shared memory, avoiding an extra copy between processes on the
+    same host.
+
+    Args:
+        session: An open :class:`zenoh.Session`.
+        key_expr: Zenoh key expression (topic name) to publish on.
+        template: A template instance (from ``FrameBuffer.template()``) whose
+            field layout defines the wire format.  Not used at runtime but kept
+            for symmetry with :class:`ZenohReader`.
+    """
+
+    def __init__(self, session: zenoh.Session, key_expr: str, template: Any) -> None:
+        self._publisher = session.declare_publisher(key_expr)
+        self._template = template
+        atexit.register(self.stop)
+
+    def __call__(self, msg: Any) -> None:
+        """Serialize *msg* and publish it.
+
+        Args:
+            msg: A frame buffer dataclass instance (same type as the template).
+        """
+        self._publisher.put(serialize_frame(msg))
+
+    def stop(self) -> None:
+        """Undeclare the publisher and release its resources."""
+        try:
+            self._publisher.undeclare()
+        except Exception:
+            pass
+        atexit.unregister(self.stop)

--- a/airo-camera-toolkit/airo_camera_toolkit/cameras/zed/zed.py
+++ b/airo-camera-toolkit/airo_camera_toolkit/cameras/zed/zed.py
@@ -606,7 +606,7 @@ class Zed(StereoRGBDCamera):
 
         # We use cv2.cvtColor because, unlike a slice (point_cloud_XYZ_[..., :3]), it returns a contiguous array.
         # Downstream code can avoid a copy/explicitly making the array contiguous if it is contiguous.
-        # For example, in shared memory transport with airo-ipc, non-contiguous arrays incur a cost.
+        # For example, in Zenoh's shared memory transport, non-contiguous arrays incur an extra copy cost.
         # See also: https://github.com/airo-ugent/airo-mono/issues/177 for discussion and benchmarks.
         positions = cv2.cvtColor(point_cloud_XYZ_, cv2.COLOR_BGRA2BGR).reshape(-1, 3)
         colors = self.retrieve_rgb_image_as_int().reshape(-1, 3)

--- a/airo-camera-toolkit/benchmarks/benchmark_multiprocess_rgbd_latency.py
+++ b/airo-camera-toolkit/benchmarks/benchmark_multiprocess_rgbd_latency.py
@@ -1,0 +1,196 @@
+"""Latency benchmark for the multiprocess RGBD camera pipeline.
+
+Measures end-to-end latency from frame capture (publisher side) to
+frame availability (receiver side) for FullHD (1920×1080) RGBD images
+published at 60 FPS using Zenoh with shared-memory transport.
+
+Frame data size (RGBDFrameBuffer, no point cloud):
+  RGB image:    1920 × 1080 × 3 × uint8  =   6.2 MB
+  Depth image:  1920 × 1080 × 3 × uint8  =   6.2 MB
+  Depth map:    1920 × 1080 × 1 × float32 =   8.3 MB
+  Intrinsics:   3 × 3 × float64           =   0.0 MB
+  ─────────────────────────────────────────────────
+  Total per frame                          ≈  20.7 MB
+  At 60 FPS                                ≈ 1.24 GB/s
+
+Latency is measured as:
+  latency = time_received − frame_timestamp
+
+where ``frame_timestamp`` is set by the publisher immediately after
+``camera.grab_images()`` returns, and ``time_received`` is recorded in
+the receiver immediately after ``grab_images()`` returns.
+
+Usage::
+
+    python benchmarks/benchmark_multiprocess_rgbd_latency.py
+
+Optional arguments::
+
+    --duration   How many seconds to run (default: 10)
+    --namespace  Zenoh key-expression namespace (default: bench_rgbd)
+    --fps        Target publisher FPS (default: 60)
+    --no-shm     Disable Zenoh shared-memory transport
+"""
+
+from __future__ import annotations
+
+import argparse
+import multiprocessing
+import time
+from typing import List
+
+import numpy as np
+from airo_camera_toolkit.cameras.multiprocess.multiprocess_rgbd_camera import (
+    MultiprocessRGBDPublisher,
+    MultiprocessRGBDReceiver,
+)
+from airo_camera_toolkit.interfaces import RGBDCamera
+from airo_typing import (
+    CameraIntrinsicsMatrixType,
+    CameraResolutionType,
+    NumpyDepthMapType,
+    NumpyFloatImageType,
+    NumpyIntImageType,
+)
+
+# ---------------------------------------------------------------------------
+# FullHD constants
+# ---------------------------------------------------------------------------
+
+RESOLUTION = (1920, 1080)  # (width, height)
+W, H = RESOLUTION
+
+# Pre-allocate static image data so the mock camera avoids per-frame allocation
+_RGB = np.zeros((H, W, 3), dtype=np.uint8)
+_DEPTH_MAP = np.ones((H, W), dtype=np.float32) * 1.5
+_DEPTH_IMAGE = np.zeros((H, W, 3), dtype=np.uint8)
+_INTRINSICS = np.array([[1000.0, 0.0, 960.0], [0.0, 1000.0, 540.0], [0.0, 0.0, 1.0]], dtype=np.float64)
+
+
+# ---------------------------------------------------------------------------
+# Mock camera
+# ---------------------------------------------------------------------------
+
+
+class MockFullHDRGBDCamera(RGBDCamera):
+    """Mock FullHD RGBD camera that returns static pre-allocated arrays."""
+
+    def __init__(self, fps: float = 60.0) -> None:
+        self._fps = fps
+        self._period = 1.0 / fps
+
+    @property
+    def resolution(self) -> CameraResolutionType:
+        return RESOLUTION
+
+    @property
+    def fps(self) -> float:
+        return self._fps
+
+    def grab_images(self) -> None:
+        time.sleep(self._period)
+
+    def retrieve_rgb_image(self) -> NumpyFloatImageType:
+        return _RGB.astype(np.float32) / 255.0
+
+    def retrieve_rgb_image_as_int(self) -> NumpyIntImageType:
+        return _RGB
+
+    def intrinsics_matrix(self) -> CameraIntrinsicsMatrixType:
+        return _INTRINSICS
+
+    def retrieve_depth_map(self) -> NumpyDepthMapType:
+        return _DEPTH_MAP
+
+    def retrieve_depth_image(self) -> NumpyIntImageType:
+        return _DEPTH_IMAGE
+
+
+# ---------------------------------------------------------------------------
+# Benchmark runner
+# ---------------------------------------------------------------------------
+
+
+def run_benchmark(duration: float, namespace: str, fps: float) -> None:
+    multiprocessing.set_start_method("spawn", force=True)
+
+    frame_size_mb = (
+        _RGB.nbytes
+        + _DEPTH_MAP.nbytes
+        + _DEPTH_IMAGE.nbytes
+        + _INTRINSICS.nbytes
+        + 8
+        + 8  # frame_id  # frame_timestamp
+    ) / (1024**2)
+
+    print(f"\n{'─' * 60}")
+    print("  Multiprocess RGBD Latency Benchmark")
+    print(f"{'─' * 60}")
+    print(f"  Resolution   : {W} × {H}")
+    print(f"  Target FPS   : {fps:.0f}")
+    print(f"  Frame size   : {frame_size_mb:.1f} MB")
+    print(f"  Bandwidth    : {frame_size_mb * fps / 1024:.2f} GB/s (theoretical)")
+    print(f"  Duration     : {duration:.0f} s")
+    print(f"{'─' * 60}\n")
+
+    publisher = MultiprocessRGBDPublisher(
+        camera_cls=MockFullHDRGBDCamera,
+        camera_kwargs={"fps": fps},
+        shared_memory_namespace=namespace,
+        enable_pointcloud=False,
+    )
+    publisher.start()
+
+    print("Waiting for receiver to connect...")
+    receiver = MultiprocessRGBDReceiver(namespace, enable_pointcloud=False)
+    print("Connected. Collecting latency samples...\n")
+
+    latencies_ms: List[float] = []
+    t_start = time.time()
+    frames_received = 0
+
+    while time.time() - t_start < duration:
+        receiver.grab_images()
+        t_received = time.time()
+        latency_ms = (t_received - receiver.get_current_timestamp()) * 1000.0
+        latencies_ms.append(latency_ms)
+        frames_received += 1
+
+    elapsed = time.time() - t_start
+    publisher.stop()
+    publisher.join(timeout=5)
+
+    # ---------------------------------------------------------------------------
+    # Statistics
+    # ---------------------------------------------------------------------------
+    a = np.array(latencies_ms)
+
+    print(f"{'─' * 60}")
+    print(f"  Results  ({frames_received} frames over {elapsed:.1f} s)")
+    print(f"{'─' * 60}")
+    print(f"  Achieved FPS  : {frames_received / elapsed:.1f}")
+    print("  Latency (ms):")
+    print(f"    mean        : {a.mean():.2f}")
+    print(f"    std         : {a.std():.2f}")
+    print(f"    min         : {a.min():.2f}")
+    print(f"    median (p50): {np.percentile(a, 50):.2f}")
+    print(f"    p95         : {np.percentile(a, 95):.2f}")
+    print(f"    p99         : {np.percentile(a, 99):.2f}")
+    print(f"    max         : {a.max():.2f}")
+    print(f"{'─' * 60}\n")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--duration", type=float, default=10.0, help="Benchmark duration in seconds (default: 10)")
+    parser.add_argument(
+        "--namespace", type=str, default="bench_rgbd", help="Zenoh key-expression namespace (default: bench_rgbd)"
+    )
+    parser.add_argument("--fps", type=float, default=60.0, help="Target publisher FPS (default: 60)")
+    args = parser.parse_args()
+
+    run_benchmark(duration=args.duration, namespace=args.namespace, fps=args.fps)

--- a/airo-camera-toolkit/benchmarks/benchmark_multiprocess_rgbd_latency.py
+++ b/airo-camera-toolkit/benchmarks/benchmark_multiprocess_rgbd_latency.py
@@ -37,7 +37,6 @@ from __future__ import annotations
 import argparse
 import multiprocessing
 import time
-from typing import List
 
 import numpy as np
 from airo_camera_toolkit.cameras.multiprocess.multiprocess_rgbd_camera import (
@@ -111,6 +110,25 @@ class MockFullHDRGBDCamera(RGBDCamera):
 # ---------------------------------------------------------------------------
 
 
+def _receiver_worker(namespace: str, duration: float, result_queue: multiprocessing.Queue) -> None:
+    """Runs in its own subprocess: connects receiver, collects latency samples."""
+    import time
+
+    receiver = MultiprocessRGBDReceiver(namespace, enable_pointcloud=False)
+
+    latencies_ms = []
+    t_start = time.time()
+
+    while time.time() - t_start < duration:
+        receiver.grab_images()
+        t_received = time.time()
+        latency_ms = (t_received - receiver.get_current_timestamp()) * 1000.0
+        latencies_ms.append(latency_ms)
+
+    elapsed = time.time() - t_start
+    result_queue.put((latencies_ms, elapsed))
+
+
 def run_benchmark(duration: float, namespace: str, fps: float) -> None:
     multiprocessing.set_start_method("spawn", force=True)
 
@@ -141,24 +159,21 @@ def run_benchmark(duration: float, namespace: str, fps: float) -> None:
     )
     publisher.start()
 
+    result_queue: multiprocessing.Queue = multiprocessing.Queue()
+    receiver_proc = multiprocessing.Process(
+        target=_receiver_worker,
+        args=(namespace, duration, result_queue),
+    )
     print("Waiting for receiver to connect...")
-    receiver = MultiprocessRGBDReceiver(namespace, enable_pointcloud=False)
-    print("Connected. Collecting latency samples...\n")
-
-    latencies_ms: List[float] = []
     t_start = time.time()
-    frames_received = 0
-
-    while time.time() - t_start < duration:
-        receiver.grab_images()
-        t_received = time.time()
-        latency_ms = (t_received - receiver.get_current_timestamp()) * 1000.0
-        latencies_ms.append(latency_ms)
-        frames_received += 1
-
+    receiver_proc.start()
+    receiver_proc.join()
     elapsed = time.time() - t_start
+
     publisher.stop()
     publisher.join(timeout=5)
+
+    latencies_ms, elapsed = result_queue.get()
 
     # ---------------------------------------------------------------------------
     # Statistics
@@ -166,9 +181,9 @@ def run_benchmark(duration: float, namespace: str, fps: float) -> None:
     a = np.array(latencies_ms)
 
     print(f"{'─' * 60}")
-    print(f"  Results  ({frames_received} frames over {elapsed:.1f} s)")
+    print(f"  Results  ({len(a)} frames over {elapsed:.1f} s)")
     print(f"{'─' * 60}")
-    print(f"  Achieved FPS  : {frames_received / elapsed:.1f}")
+    print(f"  Achieved FPS  : {len(a) / elapsed:.1f}")
     print("  Latency (ms):")
     print(f"    mean        : {a.mean():.2f}")
     print(f"    std         : {a.std():.2f}")

--- a/airo-camera-toolkit/setup.py
+++ b/airo-camera-toolkit/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
         "click",
         "open3d",
         "loguru",
-        "zenoh",
+        "eclipse-zenoh",
         "airo-typing>=2026.1.0",
         "airo-spatial-algebra>=2026.1.0",
         "airo-dataset-tools>=2026.1.0",

--- a/airo-camera-toolkit/setup.py
+++ b/airo-camera-toolkit/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
         "click",
         "open3d",
         "loguru",
-        "airo-ipc>=0.1.0",
+        "zenoh",
         "airo-typing>=2026.1.0",
         "airo-spatial-algebra>=2026.1.0",
         "airo-dataset-tools>=2026.1.0",

--- a/airo-camera-toolkit/test/test_frame_data.py
+++ b/airo-camera-toolkit/test/test_frame_data.py
@@ -1,0 +1,188 @@
+"""Unit tests for frame_data serialization round-trips."""
+
+import numpy as np
+import pytest
+from airo_camera_toolkit.cameras.multiprocess.frame_data import (
+    FpsIdl,
+    PointCloudBuffer,
+    ResolutionIdl,
+    RGBDFrameBuffer,
+    RGBDFrameBufferWithPointCloud,
+    RGBFrameBuffer,
+    SpatialMapBuffer,
+    StereoRGBDFrameBuffer,
+    StereoRGBDFrameBufferWithPointCloud,
+    ZedFrameBuffer,
+    deserialize_frame,
+    serialize_frame,
+)
+
+W, H = 64, 48  # small resolution for fast tests
+
+
+def _assert_frame_equal(a, b) -> None:
+    import dataclasses
+
+    for f in dataclasses.fields(a):
+        np.testing.assert_array_equal(getattr(a, f.name), getattr(b, f.name), err_msg=f"field '{f.name}' mismatch")
+
+
+# ---------------------------------------------------------------------------
+# Metadata buffers
+# ---------------------------------------------------------------------------
+
+
+def test_fps_idl_round_trip():
+    obj = FpsIdl(fps=np.array([42.0], dtype=np.float64))
+    result = deserialize_frame(FpsIdl.template(), serialize_frame(obj))
+    assert result.fps.item() == pytest.approx(42.0)
+
+
+def test_resolution_idl_round_trip():
+    obj = ResolutionIdl(resolution=np.array([1920, 1080], dtype=np.int32))
+    result = deserialize_frame(ResolutionIdl.template(), serialize_frame(obj))
+    np.testing.assert_array_equal(result.resolution, [1920, 1080])
+
+
+# ---------------------------------------------------------------------------
+# Frame buffers
+# ---------------------------------------------------------------------------
+
+
+def test_rgb_frame_buffer_round_trip():
+    rgb = np.random.randint(0, 255, (H, W, 3), dtype=np.uint8)
+    intrinsics = np.eye(3, dtype=np.float64) * 500.0
+    obj = RGBFrameBuffer(
+        frame_id=np.array([7], dtype=np.uint64),
+        frame_timestamp=np.array([1.23456789], dtype=np.float64),
+        rgb=rgb,
+        intrinsics=intrinsics,
+    )
+    result = deserialize_frame(RGBFrameBuffer.template(W, H), serialize_frame(obj))
+    _assert_frame_equal(obj, result)
+
+
+def test_rgbd_frame_buffer_round_trip():
+    obj = RGBDFrameBuffer(
+        frame_id=np.array([1], dtype=np.uint64),
+        frame_timestamp=np.array([0.5], dtype=np.float64),
+        rgb=np.zeros((H, W, 3), dtype=np.uint8),
+        intrinsics=np.eye(3, dtype=np.float64),
+        depth_image=np.zeros((H, W, 3), dtype=np.uint8),
+        depth=np.ones((H, W), dtype=np.float32) * 2.5,
+    )
+    result = deserialize_frame(RGBDFrameBuffer.template(W, H), serialize_frame(obj))
+    _assert_frame_equal(obj, result)
+
+
+def test_rgbd_frame_buffer_with_pointcloud_round_trip():
+    n = H * W
+    obj = RGBDFrameBufferWithPointCloud(
+        frame_id=np.array([2], dtype=np.uint64),
+        frame_timestamp=np.array([1.0], dtype=np.float64),
+        rgb=np.zeros((H, W, 3), dtype=np.uint8),
+        intrinsics=np.eye(3, dtype=np.float64),
+        depth_image=np.zeros((H, W, 3), dtype=np.uint8),
+        depth=np.zeros((H, W), dtype=np.float32),
+        point_cloud_positions=np.random.rand(n, 3).astype(np.float32),
+        point_cloud_colors=np.zeros((n, 3), dtype=np.uint8),
+        num_valid_points=np.array([n // 2], dtype=np.int32),
+    )
+    result = deserialize_frame(RGBDFrameBufferWithPointCloud.template(W, H), serialize_frame(obj))
+    _assert_frame_equal(obj, result)
+
+
+def test_stereo_rgbd_frame_buffer_round_trip():
+    obj = StereoRGBDFrameBuffer(
+        frame_id=np.array([3], dtype=np.uint64),
+        frame_timestamp=np.array([2.0], dtype=np.float64),
+        rgb=np.zeros((H, W, 3), dtype=np.uint8),
+        intrinsics=np.eye(3, dtype=np.float64),
+        depth_image=np.zeros((H, W, 3), dtype=np.uint8),
+        depth=np.zeros((H, W), dtype=np.float32),
+        rgb_right=np.ones((H, W, 3), dtype=np.uint8) * 128,
+        intrinsics_right=np.eye(3, dtype=np.float64) * 2.0,
+        pose_right_in_left=np.eye(4, dtype=np.float64),
+    )
+    result = deserialize_frame(StereoRGBDFrameBuffer.template(W, H), serialize_frame(obj))
+    _assert_frame_equal(obj, result)
+
+
+def test_stereo_rgbd_frame_buffer_with_pointcloud_round_trip():
+    n = H * W
+    obj = StereoRGBDFrameBufferWithPointCloud(
+        frame_id=np.array([4], dtype=np.uint64),
+        frame_timestamp=np.array([3.0], dtype=np.float64),
+        rgb=np.zeros((H, W, 3), dtype=np.uint8),
+        intrinsics=np.eye(3, dtype=np.float64),
+        depth_image=np.zeros((H, W, 3), dtype=np.uint8),
+        depth=np.zeros((H, W), dtype=np.float32),
+        rgb_right=np.zeros((H, W, 3), dtype=np.uint8),
+        intrinsics_right=np.eye(3, dtype=np.float64),
+        pose_right_in_left=np.eye(4, dtype=np.float64),
+        point_cloud_positions=np.random.rand(n, 3).astype(np.float32),
+        point_cloud_colors=np.zeros((n, 3), dtype=np.uint8),
+        num_valid_points=np.array([n], dtype=np.int32),
+    )
+    result = deserialize_frame(StereoRGBDFrameBufferWithPointCloud.template(W, H), serialize_frame(obj))
+    _assert_frame_equal(obj, result)
+
+
+def test_zed_frame_buffer_round_trip():
+    obj = ZedFrameBuffer(
+        frame_id=np.array([5], dtype=np.uint64),
+        frame_timestamp=np.array([4.0], dtype=np.float64),
+        rgb=np.zeros((H, W, 3), dtype=np.uint8),
+        intrinsics=np.eye(3, dtype=np.float64),
+        depth_image=np.zeros((H, W, 3), dtype=np.uint8),
+        depth=np.zeros((H, W), dtype=np.float32),
+        rgb_right=np.zeros((H, W, 3), dtype=np.uint8),
+        intrinsics_right=np.eye(3, dtype=np.float64),
+        pose_right_in_left=np.eye(4, dtype=np.float64),
+        camera_pose=np.eye(4, dtype=np.float64),
+    )
+    result = deserialize_frame(ZedFrameBuffer.template(W, H), serialize_frame(obj))
+    _assert_frame_equal(obj, result)
+
+
+def test_point_cloud_buffer_round_trip():
+    n = H * W
+    obj = PointCloudBuffer(
+        frame_id=np.array([6], dtype=np.uint64),
+        frame_timestamp=np.array([5.0], dtype=np.float64),
+        point_cloud_positions=np.random.rand(n, 3).astype(np.float32),
+        point_cloud_colors=np.zeros((n, 3), dtype=np.uint8),
+        point_cloud_valid=np.array([n // 2], dtype=np.int32),
+    )
+    result = deserialize_frame(PointCloudBuffer.template(W, H), serialize_frame(obj))
+    _assert_frame_equal(obj, result)
+
+
+def test_spatial_map_buffer_round_trip():
+    max_chunks, max_points = 10, 1000
+    obj = SpatialMapBuffer(
+        frame_id=np.array([0], dtype=np.uint64),
+        frame_timestamp=np.array([6.0], dtype=np.float64),
+        num_chunks=np.array([3], dtype=np.int32),
+        chunks_updated=np.array([True, False, True] + [False] * (max_chunks - 3), dtype=np.bool_),
+        chunk_sizes=np.array([100, 200, 300] + [0] * (max_chunks - 3), dtype=np.int32),
+        point_positions=np.random.rand(max_points, 3).astype(np.float32),
+        point_colors=np.zeros((max_points, 3), dtype=np.uint8),
+    )
+    result = deserialize_frame(SpatialMapBuffer.template(max_chunks, max_points), serialize_frame(obj))
+    _assert_frame_equal(obj, result)
+
+
+# ---------------------------------------------------------------------------
+# Edge case: deserialized arrays are independent copies (not shared memory)
+# ---------------------------------------------------------------------------
+
+
+def test_deserialized_arrays_are_copies():
+    obj = FpsIdl(fps=np.array([30.0], dtype=np.float64))
+    data = serialize_frame(obj)
+    result = deserialize_frame(FpsIdl.template(), data)
+    result.fps[0] = 99.0
+    # Modifying the result must not affect the original bytes
+    result2 = deserialize_frame(FpsIdl.template(), data)
+    assert result2.fps.item() == pytest.approx(30.0)

--- a/airo-camera-toolkit/test/test_multiprocess_rgb.py
+++ b/airo-camera-toolkit/test/test_multiprocess_rgb.py
@@ -1,0 +1,143 @@
+"""Integration tests for the full multiprocess camera pipeline using a mock camera.
+
+These tests spawn a real MultiprocessRGBPublisher (in a subprocess) backed by a
+MockRGBCamera and verify that a MultiprocessRGBReceiver in the main process
+receives frames correctly via Zenoh.
+
+No real camera hardware is required.  Requires ``eclipse-zenoh`` to be installed;
+tests are skipped automatically when it is not available.
+"""
+
+import multiprocessing
+import time
+
+import pytest
+
+pytest.importorskip("zenoh", reason="eclipse-zenoh not installed")
+
+import numpy as np
+import pytest
+from airo_camera_toolkit.cameras.multiprocess.multiprocess_rgb_camera import (
+    MultiprocessRGBPublisher,
+    MultiprocessRGBReceiver,
+)
+from airo_camera_toolkit.interfaces import RGBCamera
+from airo_typing import CameraIntrinsicsMatrixType, CameraResolutionType, NumpyFloatImageType, NumpyIntImageType
+
+# ---------------------------------------------------------------------------
+# Mock camera
+# ---------------------------------------------------------------------------
+
+_MOCK_RESOLUTION = (64, 48)  # (width, height) — small for fast tests
+_MOCK_FPS = 30
+_MOCK_RGB_VALUE = 128  # constant pixel value so we can assert equality
+
+
+class MockRGBCamera(RGBCamera):
+    """Minimal RGB camera that returns fixed images without any hardware."""
+
+    @property
+    def resolution(self) -> CameraResolutionType:
+        return _MOCK_RESOLUTION
+
+    @property
+    def fps(self) -> float:
+        return _MOCK_FPS
+
+    def grab_images(self) -> None:
+        # Simulate a small capture delay so the publisher doesn't spin too fast
+        time.sleep(1.0 / _MOCK_FPS)
+
+    def retrieve_rgb_image(self) -> NumpyFloatImageType:
+        return self.retrieve_rgb_image_as_int().astype(np.float32) / 255.0
+
+    def retrieve_rgb_image_as_int(self) -> NumpyIntImageType:
+        w, h = _MOCK_RESOLUTION
+        return np.full((h, w, 3), _MOCK_RGB_VALUE, dtype=np.uint8)
+
+    def intrinsics_matrix(self) -> CameraIntrinsicsMatrixType:
+        return np.eye(3, dtype=np.float64) * 500.0
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_NAMESPACE = "test_camera_mock"
+_STARTUP_TIMEOUT = 15  # seconds to wait for publisher to be ready
+
+
+@pytest.fixture()
+def publisher():
+    """Start a MultiprocessRGBPublisher and stop it after the test."""
+    multiprocessing.set_start_method("spawn", force=True)
+    pub = MultiprocessRGBPublisher(
+        camera_cls=MockRGBCamera,
+        shared_memory_namespace=_NAMESPACE,
+    )
+    pub.start()
+    yield pub
+    pub.stop()
+    pub.join(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_receiver_reads_resolution_and_fps(publisher):
+    """Receiver should report the same resolution and fps as the mock camera."""
+    receiver = MultiprocessRGBReceiver(_NAMESPACE)
+    assert receiver.resolution == _MOCK_RESOLUTION
+    assert receiver.fps == _MOCK_FPS
+
+
+def test_receiver_gets_rgb_image(publisher):
+    """Receiver should return an RGB image with the expected shape and values."""
+    receiver = MultiprocessRGBReceiver(_NAMESPACE)
+    receiver.grab_images()
+
+    image = receiver.retrieve_rgb_image_as_int()
+    w, h = _MOCK_RESOLUTION
+    assert image.shape == (h, w, 3)
+    assert image.dtype == np.uint8
+    np.testing.assert_array_equal(image, _MOCK_RGB_VALUE)
+
+
+def test_receiver_frame_timestamp_advances(publisher):
+    """Consecutive grab_images() calls should yield strictly increasing timestamps."""
+    receiver = MultiprocessRGBReceiver(_NAMESPACE)
+
+    receiver.grab_images()
+    t0 = receiver.get_current_timestamp()
+
+    receiver.grab_images()
+    t1 = receiver.get_current_timestamp()
+
+    assert t1 > t0, f"Timestamp did not advance: {t0} -> {t1}"
+
+
+def test_receiver_frame_id_advances(publisher):
+    """Frame IDs should be monotonically increasing."""
+    receiver = MultiprocessRGBReceiver(_NAMESPACE)
+
+    receiver.grab_images()
+    id0 = receiver.get_current_frame_id()
+
+    receiver.grab_images()
+    id1 = receiver.get_current_frame_id()
+
+    assert id1 > id0, f"Frame ID did not advance: {id0} -> {id1}"
+
+
+def test_multiple_receivers_same_namespace(publisher):
+    """Multiple receivers on the same namespace should all get valid frames."""
+    r1 = MultiprocessRGBReceiver(_NAMESPACE)
+    r2 = MultiprocessRGBReceiver(_NAMESPACE)
+
+    r1.grab_images()
+    r2.grab_images()
+
+    np.testing.assert_array_equal(r1.retrieve_rgb_image_as_int(), _MOCK_RGB_VALUE)
+    np.testing.assert_array_equal(r2.retrieve_rgb_image_as_int(), _MOCK_RGB_VALUE)


### PR DESCRIPTION
- Replace CycloneDDS-based shared memory (airo-ipc) with Zenoh pub/sub, with shared memory transport enabled by default
- Drop BaseIdl inheritance from all frame buffer dataclasses; use plain @dataclass throughout frame_data.py
- Add serialize_frame() / deserialize_frame() helpers: fields packed as raw bytes in dataclass field declaration order
- Add ZenohWriter (replaces SMWriter): declares a Zenoh publisher, serializes frame buffers, calls put()
- Add ZenohReader (replaces SMReader): subscribes with a callback, stores latest bytes under a threading.Lock, deserializes on __call__()
- Update base_publisher.py and base_receiver.py: replace DomainParticipant
  + SM{Writer,Reader} with zenoh.Session + Zenoh{Writer,Reader}; rename self._dp -> self._session throughout
- Update multiprocess_zed_camera.py: replace direct SMWriter/SMReader imports for point cloud and spatial map topics
- Update setup.py: replace airo-ipc>=0.1.0 with zenoh

Public API of all Multiprocess*Publisher / Multiprocess*Receiver classes is unchanged.

## Describe your changes


## Checklist
- [ ] Have you modified the changelog?
- [ ] If you made changes to the hardware interfaces, have you tested them using the manual tests?
