### PR TITLE
fix(airo-camera-toolkit): normalize rotation matrix before drawing frame on image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project uses a [CalVer](https://calver.org/) versioning scheme with monthly
 
 ### Fixed
 - `airo-camera-toolkit`: `get_pose_of_charuco_board` now returns `None` instead of crashing when fewer than 6 charuco corners are detected (OpenCV's DLT algorithm requires at least 6 point correspondences). Fixes [#199](https://github.com/airo-ugent/airo-mono/issues/199).
+- `airo-camera-toolkit`: `draw_frame_on_image` no longer crashes with `ValueError: bad argument to constructor` when the rotation part of the pose has drifted slightly off SO(3) due to floating-point error (e.g. after the chained matrix inversions/multiplications in hand-eye calibration's `draw_base_pose_on_image`).
 
 ### Removed
 

--- a/airo-camera-toolkit/airo_camera_toolkit/calibration/fiducial_markers.py
+++ b/airo-camera-toolkit/airo_camera_toolkit/calibration/fiducial_markers.py
@@ -11,6 +11,7 @@ from typing import List, Optional
 import cv2
 import numpy as np
 from airo_spatial_algebra import SE3Container
+from airo_spatial_algebra.se3 import normalize_so3_matrix
 from airo_typing import CameraIntrinsicsMatrixType, HomogeneousMatrixType, OpenCVIntImageType
 from cv2 import aruco
 
@@ -187,6 +188,10 @@ def draw_frame_on_image(
     camera_matrix: CameraIntrinsicsMatrixType,
 ) -> OpenCVIntImageType:
     """Draws a 2D projection of a frame on the image. Be careful when interpreting this visually, it is often hard to estimate the true 3D direction of an axis' 2D projection."""
+    # the rotation part can drift slightly off SO(3) after chained inversions/multiplications (e.g. in
+    # draw_base_pose_on_image), which makes SE3Container reject the matrix; normalize to fix this.
+    frame_pose_in_camera = frame_pose_in_camera.copy()
+    frame_pose_in_camera[:3, :3] = normalize_so3_matrix(frame_pose_in_camera[:3, :3])
     charuco_se3 = SE3Container.from_homogeneous_matrix(frame_pose_in_camera)
     rvec = charuco_se3.orientation_as_rotation_vector
     tvec = charuco_se3.translation


### PR DESCRIPTION
## Summary
- Fixes `ValueError: bad argument to constructor` raised by `SE3Container.from_homogeneous_matrix` during hand-eye calibration's live/result visualization (`draw_base_pose_on_image` → `draw_frame_on_image`).
- Root cause: the rotation part of the pose can drift slightly off SO(3) due to floating-point error from `cv2.calibrateHandEye` plus the chained `np.linalg.inv`/matmul operations in `draw_base_pose_on_image`. `SE3Container`'s strict `np.allclose` orthonormality check then rejects it.
- Fix: normalize the rotation matrix with `airo_spatial_algebra.se3.normalize_so3_matrix` before constructing the `SE3Container` in `draw_frame_on_image`.

## Test plan
- [x] Reproduced the failure with a synthetic slightly-non-orthonormal rotation matrix and confirmed `normalize_so3_matrix` fixes it
- [x] `pytest airo-camera-toolkit/test -k "calibration or fiducial or marker"` passes
- [x] `pre-commit run` passes on the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)