### PR TITLE
Add FANUC manipulator and Robotiq 2F-85 on FANUC support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes for the packages in the airo-mono repo are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project uses a [CalVer](https://calver.org/) versioning scheme with monthly releases, see [here](versioning.md)
 
+## Unreleased
+
+### Added
+- `airo-robots`: Added `Fanuc`, a `PositionManipulator` implementation for FANUC robots using the [airo-fanuc](https://github.com/airo-ugent/airo-fanuc) driver (Stream Motion + RMI), installed with `pip install "airo-robots[fanuc]"`. The driver does no kinematics, so every Cartesian and kinematics method raises `NotImplementedError` and points at a numerical solver on a FANUC URDF; joint-space control, `get_tcp_pose` and `execute_trajectory` are supported. See [fanuc_setup.md](airo-robots/airo_robots/manipulators/hardware/fanuc_setup.md).
+- `airo-robots`: Added `Robotiq2F85Fanuc`, a `ParallelPositionGripper` implementation for a Robotiq 2F-85 wired to a FANUC controller and actuated over the controller's registers. Only a few discrete openings and force classes are reachable, so `move` snaps a requested width to the nearest one, and everything needing feedback or a continuous setpoint raises `NotImplementedError`. See [fanuc_robotiq.md](airo-robots/airo_robots/grippers/hardware/fanuc_robotiq.md).
+
+### Fixed
+- `airo-robots`: `loguru` is now declared as a dependency. It was already imported by the shipped hardware implementations but only installed as a side effect of `airo-camera-toolkit`.
+
 ## 2026.7.0
 
 Released: 2026-07-28

--- a/airo-robots/README.md
+++ b/airo-robots/README.md
@@ -9,8 +9,10 @@ The following combinations of hardware and communication options are currently i
 |----------|:----------|----------------|
 | UR robots | RTDE | [ur_rtde.py](airo_robots/manipulators/hardware/ur_rtde.py) |
 | RealMan robots | RealMan Python API | [realman.py](airo_robots/manipulators/hardware/realman.py) |
+| FANUC robots | airo-fanuc API (Stream Motion + RMI) | [fanuc.py](airo_robots/manipulators/hardware/fanuc.py) |
 |Schunk EGK gripper | Modbus-USB converter | [schunk_process.py](airo_robots/grippers/hardware/schunk_process.py) |
 | Robotiq 2F85 gripper | URCap web API | [robotiq_2f85_urcap.py](airo_robots/grippers/hardware/robotiq_2f85_urcap.py) |
+| Robotiq 2F85 gripper on a FANUC | airo-fanuc API (RMI registers + a teach-pendant program) | [robotiq_2f85_fanuc.py](airo_robots/grippers/hardware/robotiq_2f85_fanuc.py) |
 | KELO Robile platform | airo-tulip API | [kelo_robile.py](airo_robots/drives/hardware/kelo_robile.py) |
 
 Each hardware implementation module will have a `__main__` codeblock that runs the tests for that hardware implementation. This is useful to check if the hardware is connected correctly and the implementation is working as expected. But it is also the place to be to get an idea of how to use the implementation.
@@ -38,6 +40,7 @@ You can simply pip install this package. The vendor SDKs for the hardware implem
 ```shell
 pip install "airo-robots[ur]"       # UR robots (ur-rtde)
 pip install "airo-robots[realman]"  # RealMan robots (Robotic_Arm)
+pip install "airo-robots[fanuc]"    # FANUC robots, and a Robotiq 2F-85 on one (airo-fanuc)
 pip install "airo-robots[schunk]"   # Schunk EGK40 gripper (bkstools)
 pip install "airo-robots[kelo]"     # KELO mobile platform (airo-tulip)
 ```
@@ -55,14 +58,22 @@ airo_robots/
         bimanual_position_manipulator.py    # base class for bimanual manipulators
         hardware/                           # contains the implementations of the inferfaces
             manual_gripper_testing.py       # code for manually testing hw implementations
+            fanuc.py                        # implementation for FANUC robots over the airo-fanuc driver
+            fanuc_setup.md                  # what a FANUC needs before this implementation can drive it
             realman.py                      # implementation for RealMan robots over the official Python API
+            realman_setup.md                # what a RealMan needs before this implementation can drive it
             ur_rtde.py                      # implementation of the interfaces for UR robots over the RTDE interface
+            universal_robots_setup.md       # what a UR needs before this implementation can drive it
 
     grippers/
         parallel_position_gripper.py        # base classes for parallel-finger, position-controlled grippers
         hardware/
             manual_gripper_testing.py           # code for manually testing hw implementations
+            readme.md                             # notes on the gripper implementations
+            fanuc_robotiq.md                      # what a robotiq_2F85 on a FANUC can and cannot do, and why
+            robotiq_2f85_fanuc.py                 # implementation for a robotiq_2F85 on a FANUC, over the controller's registers
             robotiq_2f85_urcap.py                 # implementations for robotiq_2F85 gripper over the URscript TCP API
+            schunk_process.py                     # implementation for the Schunk EGK40 gripper over a Modbus-USB converter
 ```
 
 ## Adding new hardware

--- a/airo-robots/airo_robots/grippers/__init__.py
+++ b/airo-robots/airo_robots/grippers/__init__.py
@@ -1,3 +1,6 @@
+# The modules imported here must stay importable without their vendor SDK installed, since importing
+# this package is on the path of every manipulator implementation.
+from airo_robots.grippers.hardware.robotiq_2f85_fanuc import Robotiq2F85Fanuc  # noqa: F401 - imported but unused
 from airo_robots.grippers.hardware.robotiq_2f85_urcap import Robotiq2F85  # noqa: F401 - imported but unused
 from airo_robots.grippers.parallel_position_gripper import (  # noqa: F401 - imported but unused
     ParallelPositionGripper,

--- a/airo-robots/airo_robots/grippers/hardware/fanuc_robotiq.md
+++ b/airo-robots/airo_robots/grippers/hardware/fanuc_robotiq.md
@@ -1,0 +1,126 @@
+# Robotiq 2F-85 on a FANUC controller
+
+[`robotiq_2f85_fanuc.py`](robotiq_2f85_fanuc.py) drives a Robotiq 2F-85 that is wired to a FANUC
+controller, through the [airo-fanuc](https://github.com/airo-ugent/airo-fanuc) driver. This is a
+different implementation from [`robotiq_2f85_urcap.py`](robotiq_2f85_urcap.py), which talks to the
+gripper's own Modbus registers over a UR control box and supports the full
+`ParallelPositionGripper` interface. Over a FANUC, most of that interface is not reachable.
+
+A FANUC controller has no gripper API, so the driver actuates the gripper the only way RMI allows: it
+writes three numeric registers, and a `GRIPDISP` teach-pendant program you install watches them and
+does the work. The driver's
+[gripper](https://github.com/airo-ugent/airo-fanuc/blob/main/docs/gripper.md) page documents that
+mechanism — the registers, the write order, the polling and the dispatcher contract. This page covers
+what it costs on the airo-mono side. See [fanuc_setup.md](../../manipulators/hardware/fanuc_setup.md)
+for setting up the arm itself.
+
+## Prerequisites
+
+- **`GRIPDISP` and `GRPRUN` installed on controller flash.** A site-installation prerequisite rather
+  than a Python dependency — `pip install` cannot supply them, and the driver's preflight refuses a
+  gripper-enabled session without them. `GRPRUN.LS` ships with the driver; `GRIPDISP` is specific to
+  how your tool is wired and is written against the specification in the driver's gripper docs.
+- **The gripper wired to the controller's tool I/O**, and working from the pendant before you try it
+  from Python.
+- **`DriverPolicy(enable_gripper=True)`** (the default), so the driver builds the gripper worker and
+  launches the dispatcher during bring-up.
+
+**Connecting opens the gripper.** Bring-up probes whether a dispatcher is already running by writing
+a benign open, so the fingers move before your code issues any command. Keep hands clear while
+connecting.
+
+## What is and is not reachable
+
+A register argument is a bucket index that `GRIPDISP` interprets — not a width in millimeters and not
+a force in newtons — so only a handful of openings and force classes exist. The figures below are the
+nominal values the module's constants carry: they select a bucket, and nothing reads them back.
+
+| Open bucket | Opening | | Close force class | Force | For |
+|---|---|---|---|---|---|
+| `OPEN_FULL` | ~85 mm, fully open | | `FORCE_LIGHT` | ~100 N | rigid or easily-crushed parts |
+| `OPEN_MID` | ~60 mm | | `FORCE_MEDIUM` | ~140 N | most things (the default) |
+| `OPEN_NARROW` | ~35 mm | | `FORCE_HARD` | ~220 N | compressible parts that only hold once squeezed |
+
+With nothing between the fingers, `FORCE_LIGHT` and `FORCE_MEDIUM` end at ~4 mm and `FORCE_HARD` at
+0 mm. With an object between them the gripper stops on the object, which is the point of closing.
+
+**Supported, with snapping:**
+
+| Method | Behaviour |
+|---|---|
+| `move(width)` | snaps to the nearest reachable opening, and logs the snap when it lands more than a millimeter from what was asked. A width that snaps to the closed position is sent as a *close* at the current force class, so the gripper stops on an object rather than at a position |
+| `open()` / `close()` | `OPEN_FULL` / a close at the current force class |
+| `max_grasp_force` | snaps to the nearest force class, and applies to this and every later close (as the interface specifies). `close_force_class` sets it by class instead of by newtons |
+| `last_commanded_width` | the nominal opening of the last command — a command, not a measurement |
+| `last_result` | the dispatcher's verdict, `{"success": bool, "message": str}` |
+
+**Not supported** (raises `NotImplementedError`), because nothing on this path can carry it:
+
+| Method | Why |
+|---|---|
+| `get_current_width` | the gripper reports no position. Use `last_commanded_width` if the last commanded opening is good enough |
+| `speed` (get and set) | `GRIPDISP` decides the finger speed; it is neither readable nor settable from here |
+| `is_an_object_grasped` | the gripper's object-detection status never reaches the controller |
+| `move(..., speed=...)` | same as `speed` |
+
+`move()` returns an `AwaitableAction` that completes when the dispatcher has cleared the trigger.
+**`success: True` is the dispatcher's word:** it means the teach-pendant program said it finished, not
+that a width was reached or an object is held — nothing in this mechanism can tell you that. The
+awaitable cannot hang, because the driver's worker always reaches a verdict within its own dispatch
+timeout; a failure is logged and `last_result` carries it.
+
+## Usage
+
+The `Fanuc` class wraps the driver's gripper worker automatically when the driver brought one up:
+
+```python
+from airo_fanuc import DriverConfig, DriverPolicy
+from airo_robots.manipulators.hardware.fanuc import Fanuc, create_crx10ial_profile
+
+policy = DriverPolicy(config=DriverConfig(profile=create_crx10ial_profile()), enable_gripper=True)
+
+with Fanuc("192.168.1.100", policy) as robot:
+    gripper = robot.gripper                  # a Robotiq2F85Fanuc
+
+    gripper.open().wait()
+    gripper.move(0.035).wait()               # OPEN_NARROW
+
+    gripper.max_grasp_force = 100            # snaps to FORCE_LIGHT
+    gripper.close().wait()
+    print(gripper.last_result)
+```
+
+Constructing it directly from a driver you brought up yourself is equivalent:
+`Robotiq2F85Fanuc(driver)`. Bucket-level control, if you would rather name the bucket than a width, is
+on the driver's own worker — `robot.driver.gripper.open_gripper(OPEN_MID)` and
+`close_gripper(FORCE_HARD)`.
+
+## A different gripper on a FANUC
+
+The register mechanism is generic, so this class implements one specific protocol — the driver's
+shipped `ROBOTIQ_2F85` preset — and its constructor refuses a driver configured with any other,
+because the bucket values would mean something else. For another gripper, write its dispatcher and a
+`RegisterGripperProtocol` for it (see the driver's gripper docs) and model a `ParallelPositionGripper`
+on this one. `Fanuc` will leave `robot.gripper` as `None` with a warning rather than guess, and
+`robot.driver.gripper` stays available for direct use.
+
+## Testing
+
+```bash
+python robotiq_2f85_fanuc.py --ip_address 192.168.1.100
+```
+
+Runs `manually_test_fanuc_gripper`: every opening bucket, an in-between width to show the snapping,
+a light close and a full-force close (put an object between the fingers for those), and then a check
+that the unsupported methods refuse. The arm does not move.
+`python ../../manipulators/hardware/fanuc.py --ip_address <ip> --gripper` runs the arm tests first
+and these afterwards.
+
+Both can be dry-run against the driver's fake controller without hardware — it implements the
+register handshake too. See the *Without hardware* section of
+[fanuc_setup.md](../../manipulators/hardware/fanuc_setup.md).
+
+Note that **the gripper path is not covered by the driver's own validation ladder**: every script in
+its `examples/` directory runs with the gripper disabled, so passing those says nothing about this.
+The driver's gripper page lists its other known limits, including why bring-up with the gripper
+enabled can need more than one attempt on a cold controller.

--- a/airo-robots/airo_robots/grippers/hardware/robotiq_2f85_fanuc.py
+++ b/airo-robots/airo_robots/grippers/hardware/robotiq_2f85_fanuc.py
@@ -1,0 +1,312 @@
+"""Parallel-position-gripper implementation for a Robotiq 2F-85 driven by a FANUC controller.
+
+Only a few discrete openings and force classes are reachable, and nothing at all is readable: see
+[fanuc_robotiq.md](fanuc_robotiq.md) for the mechanism, the buckets and what that costs.
+"""
+
+import importlib
+from types import ModuleType
+from typing import Any, Dict, Optional
+
+import numpy as np
+from airo_robots.awaitable_action import AwaitableAction
+from airo_robots.grippers.parallel_position_gripper import ParallelPositionGripper, ParallelPositionGripperSpecs
+from loguru import logger
+
+# The bucket values the GRIPDISP dispatcher on the controller understands, mirrored from
+# airo_fanuc.gripper rather than imported so that this module imports without the driver installed.
+# _assert_protocol_is_robotiq_2f85 cross-checks them against the driver's own protocol object, so the
+# mirror cannot silently drift.
+OPEN_FULL = 0
+OPEN_MID = 1
+OPEN_NARROW = 2
+
+FORCE_LIGHT = 0
+FORCE_MEDIUM = 1
+FORCE_HARD = 2
+
+# Nominal finger opening [m] of each open bucket, with the default fingertips. Nothing reads these
+# back, so they select a bucket rather than measure the fingers.
+OPEN_WIDTHS = {OPEN_FULL: 0.085, OPEN_MID: 0.060, OPEN_NARROW: 0.035}
+
+# Nominal finger opening [m] each close force class ends at with nothing between the fingers.
+CLOSE_WIDTHS = {FORCE_LIGHT: 0.004, FORCE_MEDIUM: 0.004, FORCE_HARD: 0.0}
+
+# Approximate grasp force [N] of each close force class.
+CLOSE_FORCES = {FORCE_LIGHT: 100.0, FORCE_MEDIUM: 140.0, FORCE_HARD: 220.0}
+
+# Datasheet specs of the 2F-85. The speed and force ranges describe the *gripper*; over a FANUC only
+# the buckets above are reachable.
+ROBOTIQ_2F85_FANUC_SPECS = ParallelPositionGripperSpecs(0.085, 0.0, 220, 25, 0.15, 0.02)
+
+_NO_FEEDBACK_MESSAGE = (
+    "A FANUC controller has no gripper API: the driver writes registers that a teach-pendant program "
+    "watches, and the only readable state is whether that program has finished — no width, no force, no "
+    "speed, no grasp detection. See airo_robots/grippers/hardware/fanuc_robotiq.md."
+)
+
+_NO_SPEED_MESSAGE = (
+    f"The finger speed of a Robotiq 2F-85 on a FANUC is fixed by the GRIPDISP teach-pendant program on "
+    f"the controller and can be neither read nor set from here. {_NO_FEEDBACK_MESSAGE}"
+)
+
+
+def _import_airo_fanuc_gripper() -> ModuleType:
+    """Import the optional airo-fanuc gripper module with an actionable error message."""
+    try:
+        return importlib.import_module("airo_fanuc.gripper")
+    except ImportError as exception:
+        raise ImportError(
+            'Robotiq2F85Fanuc requires the airo-fanuc driver. Install it with `pip install "airo-robots[fanuc]"`.'
+        ) from exception
+
+
+class Robotiq2F85Fanuc(ParallelPositionGripper):
+    """A Robotiq 2F-85 wired to a FANUC controller, driven through the airo-fanuc driver.
+
+    Only the discrete buckets in `OPEN_WIDTHS` and `CLOSE_FORCES` are reachable and no gripper state
+    is readable, so `move` snaps to the nearest reachable opening and everything needing feedback or a
+    continuous setpoint raises ``NotImplementedError``. ``fanuc_robotiq.md`` in this directory has the
+    mechanism, the bucket tables and the completion contract.
+
+    Args:
+        driver: a connected ``airo_fanuc.FanucDriver`` that was brought up with
+            ``DriverPolicy(enable_gripper=True)`` and the Robotiq 2F-85 protocol (the default).
+        gripper_specs: Optional specification override.
+
+    Raises:
+        ValueError: If the driver has no gripper worker, or its worker is driving a different
+            register protocol than the Robotiq 2F-85 preset this class implements.
+    """
+
+    def __init__(self, driver: Any, gripper_specs: Optional[ParallelPositionGripperSpecs] = None) -> None:
+        if driver.gripper is None:
+            raise ValueError(
+                "This FanucDriver has no gripper worker. Bring the driver up with "
+                "`DriverPolicy(..., enable_gripper=True)` (the default) so that it launches the gripper "
+                "dispatcher on the controller."
+            )
+        self._assert_protocol_is_robotiq_2f85(driver)
+
+        self.driver = driver
+        self._worker = driver.gripper
+        # The interface lets a caller set a force once and have it apply to every later move.
+        self._close_force = FORCE_MEDIUM
+        self._last_commanded_width: Optional[float] = None
+
+        super().__init__(gripper_specs if gripper_specs is not None else ROBOTIQ_2F85_FANUC_SPECS)
+
+    @staticmethod
+    def _assert_protocol_is_robotiq_2f85(driver: Any) -> None:
+        """Check the driver's register protocol against the bucket values this class assumes.
+
+        A driver whose protocol renumbers the buckets, or which is driving a different gripper
+        altogether, would otherwise have this class silently commanding the wrong bucket.
+        """
+        robotiq_protocol = _import_airo_fanuc_gripper().ROBOTIQ_2F85
+        configured = driver.gripper.protocol
+        if configured is not robotiq_protocol:
+            raise ValueError(
+                f"The driver is configured with the {configured.name!r} gripper protocol, but this class "
+                f"implements {robotiq_protocol.name!r}. Drive your own gripper through `driver.gripper` "
+                f"directly, or write a ParallelPositionGripper for it."
+            )
+        if configured.open_modifiers != tuple(OPEN_WIDTHS) or configured.close_modifiers != tuple(CLOSE_FORCES):
+            raise ValueError(
+                f"The airo-fanuc Robotiq 2F-85 protocol accepts open buckets {configured.open_modifiers} and "
+                f"close classes {configured.close_modifiers}, but this implementation was written against "
+                f"{tuple(OPEN_WIDTHS)} and {tuple(CLOSE_FORCES)}. Update this module to match the driver."
+            )
+
+    def move(self, width: float, speed: Optional[float] = None, force: Optional[float] = None) -> AwaitableAction:
+        """Move the fingers to the reachable opening closest to ``width`` [m].
+
+        A width that snaps to the closed position is sent as a *close* at the current force class, so
+        the gripper stops on an object instead of at a position.
+
+        Args:
+            width: the desired opening between the fingers [m], snapped to the nearest reachable one.
+            speed: not supported, see the `speed` property. Pass ``None``.
+            force: the maximum grasp force [N], snapped to the nearest force class and used for this
+                and every later close, as in the interface.
+
+        Raises:
+            NotImplementedError: if a speed is given.
+        """
+        if speed is not None:
+            raise NotImplementedError(_NO_SPEED_MESSAGE)
+        if force is not None:
+            self.max_grasp_force = force
+
+        target_width = float(np.clip(width, self.gripper_specs.min_width, self.gripper_specs.max_width))
+        closed_width = CLOSE_WIDTHS[self._close_force]
+        open_bucket = min(OPEN_WIDTHS, key=lambda bucket: abs(OPEN_WIDTHS[bucket] - target_width))
+
+        if abs(target_width - closed_width) < abs(target_width - OPEN_WIDTHS[open_bucket]):
+            reached, description = closed_width, f"close at force class {self._close_force}"
+            self._worker.close_gripper(self._close_force)
+        else:
+            reached, description = OPEN_WIDTHS[open_bucket], f"open bucket {open_bucket}"
+            self._worker.open_gripper(open_bucket)
+
+        if abs(reached - width) > 0.001:
+            logger.info(
+                f"A Robotiq 2F-85 on a FANUC only reaches discrete openings, so the requested {width * 1000:.1f} mm "
+                f"was sent as a {description}, which reaches about {reached * 1000:.1f} mm."
+            )
+        self._last_commanded_width = reached
+        return self._gripper_action()
+
+    def get_current_width(self) -> float:
+        """Not supported: the gripper reports nothing back over this path."""
+        raise NotImplementedError(
+            f"The opening of a Robotiq 2F-85 on a FANUC cannot be read. {_NO_FEEDBACK_MESSAGE} Use "
+            f"`gripper.last_commanded_width` if the last commanded opening is good enough for your purpose."
+        )
+
+    @property
+    def last_commanded_width(self) -> Optional[float]:
+        """The nominal opening [m] of the last command, or ``None`` before the first one.
+
+        A command, not a measurement: a close that stopped on an object ends up wider than this.
+        """
+        return self._last_commanded_width
+
+    @property
+    def speed(self) -> float:
+        """Not supported: the GRIPDISP program on the controller fixes the finger speed."""
+        raise NotImplementedError(_NO_SPEED_MESSAGE)
+
+    @speed.setter
+    def speed(self, new_speed: float) -> None:
+        """Not supported, see the `speed` property."""
+        raise NotImplementedError(_NO_SPEED_MESSAGE)
+
+    @property
+    def max_grasp_force(self) -> float:
+        """The approximate grasp force [N] of the force class the next close will use."""
+        return CLOSE_FORCES[self._close_force]
+
+    @max_grasp_force.setter
+    def max_grasp_force(self, new_force: float) -> None:
+        """Select the force class closest to ``new_force`` [N] for this and every later close."""
+        force = float(np.clip(new_force, self.gripper_specs.min_force, self.gripper_specs.max_force))
+        self._close_force = min(CLOSE_FORCES, key=lambda cls: abs(CLOSE_FORCES[cls] - force))
+        if abs(CLOSE_FORCES[self._close_force] - new_force) > 10.0:
+            logger.info(
+                f"A Robotiq 2F-85 on a FANUC only has three force classes, so the requested {new_force:.0f} N "
+                f"was rounded to class {self._close_force} (about {CLOSE_FORCES[self._close_force]:.0f} N)."
+            )
+
+    @property
+    def close_force_class(self) -> int:
+        """The force class (``FORCE_LIGHT`` / ``FORCE_MEDIUM`` / ``FORCE_HARD``) the next close will use."""
+        return self._close_force
+
+    @close_force_class.setter
+    def close_force_class(self, force_class: int) -> None:
+        if force_class not in CLOSE_FORCES:
+            raise ValueError(f"The close force class must be one of {tuple(CLOSE_FORCES)}, got {force_class!r}.")
+        self._close_force = force_class
+
+    def is_an_object_grasped(self) -> bool:
+        """Not supported: the gripper's object-detection status never reaches the FANUC controller."""
+        raise NotImplementedError(f"Grasp detection is not available on a FANUC. {_NO_FEEDBACK_MESSAGE}")
+
+    @property
+    def last_result(self) -> Optional[Dict[str, Any]]:
+        """The dispatcher's verdict on the last command: ``{"success": bool, "message": str}``.
+
+        ``success`` means the teach-pendant program said it finished, not that a width was reached or
+        an object is held. ``None`` before the first command, or while one is still running.
+        """
+        return self._worker.last_result
+
+    def _gripper_action(self) -> AwaitableAction:
+        """An AwaitableAction that completes when the dispatcher has finished the submitted command.
+
+        The driver's worker always reaches a verdict within its own dispatch timeout, so this cannot
+        hang on a wedged dispatcher: the action completes and the failure is logged.
+        """
+
+        def is_gripper_done() -> bool:
+            result = self._worker.last_result
+            if result is None:
+                return False
+            if not result["success"]:
+                logger.error(f"The FANUC gripper command did not succeed: {result['message']}")
+            return True
+
+        # The condition reads an in-process flag rather than the controller, so it can be polled fast.
+        return AwaitableAction(is_gripper_done, default_timeout=10.0, default_sleep_resolution=0.005)
+
+
+def manually_test_fanuc_gripper(gripper: Robotiq2F85Fanuc) -> None:
+    """Manually test a Robotiq 2F-85 on a FANUC.
+
+    The generic ``manually_test_gripper_implementation`` cannot be used: it reads back the finger
+    width and sets a speed, neither of which exists on this path.
+    """
+    input("gripper will now open fully")
+    gripper.open().wait()
+    print(f"result: {gripper.last_result}")
+
+    for bucket, width in OPEN_WIDTHS.items():
+        input(f"gripper will now open to bucket {bucket} (about {width * 1000:.0f} mm)")
+        gripper.move(width).wait()
+        print(f"result: {gripper.last_result}")
+
+    input("a width in between the buckets (5 cm) will now be requested, it should snap to the nearest bucket")
+    gripper.move(0.05).wait()
+    print(f"snapped to {gripper.last_commanded_width}, result: {gripper.last_result}")
+
+    input("gripper will now close lightly, you can put an object between the fingers")
+    gripper.max_grasp_force = CLOSE_FORCES[FORCE_LIGHT]
+    gripper.close().wait()
+    print(f"force class {gripper.close_force_class} ({gripper.max_grasp_force} N), result: {gripper.last_result}")
+
+    input("gripper will now close at full force")
+    gripper.max_grasp_force = gripper.gripper_specs.max_force
+    gripper.close().wait()
+    print(f"force class {gripper.close_force_class} ({gripper.max_grasp_force} N), result: {gripper.last_result}")
+
+    input("gripper will now reopen fully")
+    gripper.open().wait()
+    print(f"result: {gripper.last_result}")
+
+    for unsupported in ("get_current_width", "is_an_object_grasped"):
+        try:
+            getattr(gripper, unsupported)()
+        except NotImplementedError as exception:
+            print(f"{unsupported} is not available, as expected: {exception}")
+
+
+if __name__ == "__main__":
+    """test script for a Robotiq 2F-85 on a FANUC.
+    e.g. python airo-robots/airo_robots/grippers/hardware/robotiq_2f85_fanuc.py --ip_address 192.168.1.100
+    """
+    import click
+    from airo_robots.manipulators.hardware.fanuc import Fanuc, _import_airo_fanuc, create_crx10ial_profile
+
+    @click.command()
+    @click.option("--ip_address", default="192.168.1.100", show_default=True, help="IP address of the FANUC robot.")
+    def test_robotiq_fanuc(ip_address: str) -> None:
+        """Run the manual gripper tests against a Robotiq 2F-85 mounted on a FANUC."""
+        fanuc = _import_airo_fanuc()
+
+        print("The arm will not move, but the GRIPPER WILL: bring-up probes the dispatcher with a benign open,")
+        print("and the tests then run through every opening bucket and force class. Keep your hands clear.")
+        input(f"about to connect to the FANUC at {ip_address}, press key to start")
+
+        # Bring-up builds the gripper worker and launches the GRIPDISP dispatcher. It can take more
+        # than one attempt on a cold controller, so the driver's default of 3 retries is left alone.
+        policy = fanuc.DriverPolicy(
+            config=fanuc.DriverConfig(profile=create_crx10ial_profile()),
+            enable_gripper=True,
+        )
+        with Fanuc(ip_address, policy) as robot:
+            # `Fanuc` wraps the driver's gripper worker itself, but wrapping it here is equivalent and
+            # keeps this script independent of the class above having been imported as `__main__`.
+            manually_test_fanuc_gripper(Robotiq2F85Fanuc(robot.driver))
+
+    test_robotiq_fanuc()

--- a/airo-robots/airo_robots/manipulators/hardware/fanuc.py
+++ b/airo-robots/airo_robots/manipulators/hardware/fanuc.py
@@ -1,0 +1,805 @@
+"""Position-controlled manipulator implementation for FANUC robots, on top of the airo-fanuc driver."""
+
+import importlib
+import time
+from types import ModuleType
+from typing import Any, Callable, NoReturn, Optional
+
+import numpy as np
+from airo_robots.awaitable_action import AwaitableAction
+from airo_robots.exceptions import InvalidTrajectoryException
+from airo_robots.grippers import ParallelPositionGripper
+from airo_robots.grippers.hardware.robotiq_2f85_fanuc import Robotiq2F85Fanuc
+from airo_robots.manipulators.position_manipulator import ManipulatorSpecs, PositionManipulator
+from airo_spatial_algebra import SE3Container
+from airo_typing import (
+    HomogeneousMatrixType,
+    JointConfigurationType,
+    JointPathContainer,
+    SingleArmTrajectory,
+    WrenchType,
+)
+from loguru import logger
+
+FanucPoseType = np.ndarray
+"""A FANUC pose ``[X, Y, Z, W, P, R]`` in millimeters and degrees, as the controller reports it."""
+
+FANUC_DOF = 6
+"""The joint count of the arms this driver supports; a compile-time constant of its real-time core."""
+
+MAX_LINEAR_SPEED = 1.0
+"""Placeholder maximum TCP speed [m/s], since `ManipulatorSpecs` requires one. The driver has no
+Cartesian path, so nothing here reads it; it is not a datasheet number for any particular arm."""
+
+_KINEMATICS_MESSAGE = (
+    "The airo-fanuc driver deliberately does no kinematics: no URDF, no forward kinematics and no "
+    "inverse kinematics. Solve it outside the driver with a numerical solver on a FANUC URDF (the "
+    "CRX-10iA/L URDF lives in https://github.com/airo-ugent/airo-models), e.g. curobo or drake, and "
+    "command the resulting joint configurations. See fanuc_setup.md next to this module."
+)
+
+_NO_STATUS_PACKET_MESSAGE = "No Stream Motion status packet has been received from the FANUC controller yet"
+
+
+def _import_airo_fanuc() -> ModuleType:
+    """Import the optional airo-fanuc driver with an actionable error message."""
+    try:
+        return importlib.import_module("airo_fanuc")
+    except ImportError as exception:
+        raise ImportError(
+            'Fanuc requires the airo-fanuc driver. Install it with `pip install "airo-robots[fanuc]"`.'
+        ) from exception
+
+
+def _raise_no_kinematics(method_name: str, addition: str = "") -> NoReturn:
+    """Refuse a method that would need kinematics, pointing at an external solver instead."""
+    raise NotImplementedError(f"Fanuc.{method_name} needs kinematics. {_KINEMATICS_MESSAGE} {addition}".strip())
+
+
+class Fanuc(PositionManipulator):
+    """Control a FANUC robot through the airo-fanuc driver (https://github.com/airo-ugent/airo-fanuc).
+
+    The driver speaks Stream Motion (UDP, 125 Hz) for motion and RMI (TCP) for everything else, and
+    owns the controller exclusively while it is up. Its constructor is construct-and-go: it blocks
+    until the robot is streaming and commandable, or raises with a reason. So is this class'.
+
+    **This class does no kinematics.** The driver ships no URDF, no FK and no IK, so every Cartesian
+    command and both kinematics methods raise `NotImplementedError`; plan in joint space with an
+    external solver instead. `get_tcp_pose` is available because the *controller* computes it, with
+    its own active UTOOL applied. See `fanuc_setup.md` next to this module for the full support table.
+
+    No collision checking or obstacle avoidance is performed beyond what is configured on the
+    controller; in particular, nothing checks the servo path.
+
+    The driver exposes more than this interface does (recovery, the ARM gate, timing statistics, the
+    RMI session, register access). It stays reachable as `driver`.
+
+    Args:
+        ip_address: IP address of the robot controller.
+        policy: the driver's ``DriverPolicy``, which carries the ``DriverConfig`` and the arm's
+            ``RobotProfile``. There is no default: the profile holds the limits the real-time core
+            clamps against, and the driver cannot ask the controller which robot is attached. Build
+            one for your arm with ``python -m airo_fanuc.controller_probe --ip <ip> --emit-profile``.
+        manipulator_specs: Optional specification override. By default the maximum joint speeds are
+            taken from the profile's velocity limits and the maximum linear speed is a placeholder
+            (see `MAX_LINEAR_SPEED`).
+        gripper: Optional gripper associated with this manipulator. When it is `None` and the driver
+            brought up a Robotiq 2F-85 gripper worker, a `Robotiq2F85Fanuc` is attached automatically.
+    """
+
+    def __init__(
+        self,
+        ip_address: str,
+        policy: Any,
+        manipulator_specs: Optional[ManipulatorSpecs] = None,
+        gripper: Optional[ParallelPositionGripper] = None,
+    ) -> None:
+        self.ip_address = ip_address
+        self._fanuc = _import_airo_fanuc()
+
+        profile = policy.config.profile
+        if profile.ndof != FANUC_DOF:
+            raise ValueError(f"The airo-fanuc driver only supports {FANUC_DOF}-joint arms, got {profile.ndof}.")
+
+        self._joint_lower_limits = np.asarray(profile.position_limits_lower, dtype=float)
+        self._joint_upper_limits = np.asarray(profile.position_limits_upper, dtype=float)
+
+        if manipulator_specs is None:
+            manipulator_specs = ManipulatorSpecs(
+                np.asarray(profile.velocity_limits, dtype=float).tolist(),
+                MAX_LINEAR_SPEED,
+            )
+        if manipulator_specs.dof != FANUC_DOF:
+            raise ValueError(
+                f"Manipulator specs have {manipulator_specs.dof} joints, but the connected robot has {FANUC_DOF}."
+            )
+
+        # Construct-and-go: this blocks until the robot is commandable, or raises with a real reason.
+        self.driver: Any = self._fanuc.FanucDriver(ip_address, policy)
+        self._closed = False
+
+        super().__init__(manipulator_specs, gripper if gripper is not None else self._build_default_gripper())
+
+        # How long move_to_joint_configuration waits for the arm to come to rest before it plans.
+        self._brake_timeout = 5.0
+        # Extra time on top of a trajectory's own duration before execute_trajectory gives up on it.
+        self._trajectory_timeout_margin = 5.0
+        # Last submitted motion, so a caller can read the driver's own MotionResult after waiting.
+        self.last_motion_handle: Any = None
+
+        logger.info(
+            f"Connected to FANUC robot at {self.ip_address} with profile {profile.describe()}. "
+            f"Gripper: {type(self.gripper).__name__ if self.gripper is not None else 'none'}."
+        )
+
+    def _build_default_gripper(self) -> Optional[ParallelPositionGripper]:
+        """Wrap the driver's gripper worker when it is driving the Robotiq 2F-85 preset.
+
+        The driver builds a register worker for whatever ``gripper_protocol`` the policy names; only
+        the shipped Robotiq 2F-85 preset has a matching airo-robots implementation. Any other
+        protocol is left to the caller, since its buckets mean something this class cannot guess.
+        """
+        if self.driver.gripper is None:
+            return None
+        try:
+            return Robotiq2F85Fanuc(self.driver)
+        except ValueError as exception:
+            logger.warning(
+                f"The driver brought up a gripper worker, but it is not driving the Robotiq 2F-85 preset "
+                f"({exception}). Use `robot.driver.gripper` directly, or pass your own ParallelPositionGripper."
+            )
+            return None
+
+    def close(self) -> None:
+        """Shut the driver down: quiesce, stop streaming, disconnect and release the ownership lock."""
+        if self._closed:
+            return
+        self._closed = True
+        self.driver.close()
+
+    def __enter__(self) -> "Fanuc":
+        return self
+
+    def __exit__(self, exception_type: Any, exception: Any, traceback: Any) -> None:
+        self.close()
+
+    ###########
+    # getters #
+    ###########
+
+    def get_joint_configuration(self) -> JointConfigurationType:
+        """Get the measured joint configuration in radians.
+
+        The last position the controller reported over Stream Motion, which is published at 125 Hz. It
+        trails `get_commanded_joint_configuration` by the controller's servo lag.
+
+        Raises:
+            RuntimeError: If no status packet has arrived yet.
+        """
+        joint_configuration = self.driver.get_joint_configuration()
+        if joint_configuration is None:
+            raise RuntimeError(f"{_NO_STATUS_PACKET_MESSAGE}, so there is no joint configuration to report.")
+        return np.asarray(joint_configuration, dtype=float)
+
+    def get_commanded_joint_configuration(self) -> JointConfigurationType:
+        """Get the last *commanded* joint configuration in radians (not part of the interface).
+
+        What the driver put on the wire, as opposed to what the controller reported back. It is the
+        pose the driver anchors a new motion at, so it is the configuration a trajectory should start
+        from: the measured configuration trails it by the servo lag.
+
+        Raises:
+            RuntimeError: If no status packet has arrived yet.
+        """
+        state = self.driver.get_state()
+        # The driver gates its own getters on this, but only exposes q_cmd through the state dict.
+        # The snapshot is zero-initialized, and an all-zero configuration is a pose this arm can hold
+        # rather than a 'no data' marker, so it must not be handed out as one.
+        if int(state.get("rx_mono_ns", 0)) <= 0:
+            raise RuntimeError(f"{_NO_STATUS_PACKET_MESSAGE}, so there is no commanded joint configuration.")
+        return np.asarray(state["q_cmd"], dtype=float)
+
+    def get_tcp_pose(self) -> HomogeneousMatrixType:
+        """Get the current TCP pose as a homogeneous matrix.
+
+        The *controller* computes this pose, with the UTOOL that is active on the pendant applied, so
+        configure the UTOOL there before relying on it. This costs an RMI round trip (tens of
+        milliseconds) and is not on the 125 Hz timeline, so it does not belong in a control loop;
+        `get_flange_pose` is the streamed alternative.
+
+        Raises:
+            RuntimeError: If the controller could not be asked. No stale or substituted pose is ever
+                returned in its place.
+        """
+        pose = self.driver.get_tcp_pose()
+        if pose is None:
+            raise RuntimeError(
+                "Could not read the TCP pose from the FANUC controller (the RMI read failed). "
+                "Check `robot.driver.get_state()` for the lifecycle state and fault reason."
+            )
+        return self._convert_fanuc_pose_to_homogeneous_pose(np.asarray(pose, dtype=float))
+
+    def get_flange_pose(self) -> HomogeneousMatrixType:
+        """Get the streamed faceplate pose as a homogeneous matrix (not part of the interface).
+
+        The controller's own forward kinematics, read out of the same Stream Motion packet as the
+        measured joints, so pose and joints are the same instant. Unlike `get_tcp_pose` this does not
+        block, but it is the **faceplate** and not the tool tip: apply your own tool transform.
+
+        Raises:
+            RuntimeError: If no status packet has arrived yet.
+        """
+        pose = self.driver.get_flange_pose()
+        if pose is None:
+            raise RuntimeError(f"{_NO_STATUS_PACKET_MESSAGE}, so there is no flange pose.")
+        return self._convert_fanuc_pose_to_homogeneous_pose(np.asarray(pose, dtype=float))
+
+    def get_wrench(self) -> WrenchType:
+        """Get the end-effector six-axis force/torque reading as ``[Fx, Fy, Fz, Mx, My, Mz]`` (N, Nm).
+
+        Raises:
+            RuntimeError: If the controller streams no force block. That is the case on Stream Motion
+                v3 (type-202) controllers, which is what an R-30iB negotiates by default — on those,
+                contact detection is the controller's own collaborative stop and nothing else.
+        """
+        wrench = self.driver.get_wrench()
+        if wrench is None:
+            raise RuntimeError(
+                "This FANUC controller provides no force telemetry (no force block on the Stream Motion "
+                "wire, i.e. a v3 / type-202 status packet), so there is no wrench to read."
+            )
+        return np.asarray(wrench, dtype=float)
+
+    #############
+    # movements #
+    #############
+
+    def move_to_joint_configuration(
+        self,
+        joint_configuration: JointConfigurationType,
+        joint_speed: Optional[float] = None,
+    ) -> AwaitableAction:
+        """Move to a joint configuration with a jerk-limited point-to-point profile.
+
+        The driver plans the profile (offline Ruckig, under the arm's own limits) and hands the whole
+        timeline to its real-time core, which owns playback from there.
+
+        ``joint_speed`` is the leading-axis speed in rad/s: it caps every joint and the profile is
+        time-synchronised, so the joint with the furthest to travel runs at ``joint_speed`` and the
+        others scale down to arrive with it.
+
+        The driver refuses to plan a profile from a moving anchor, since such a plan depends on how
+        long the submission itself took and is therefore not repeatable. This brakes first when the
+        arm is not at rest, which **preempts any motion that was still running**.
+        """
+        self._assert_joint_configuration_is_valid(joint_configuration)
+        speed = self.default_joint_speed if joint_speed is None else joint_speed
+        self._assert_positive_speed(speed, "joint_speed")
+        self._assert_joint_speed_is_valid(speed)
+
+        self._brake_to_rest()
+        target = np.asarray(joint_configuration, dtype=float)
+        handle = self._submit(lambda: self.driver.move_j(target, joint_speed=speed))
+        return self._motion_action(handle, f"move to joint configuration {np.degrees(target).round(3).tolist()} deg")
+
+    def servo_to_joint_configuration(
+        self, joint_configuration: JointConfigurationType, duration: float
+    ) -> AwaitableAction:
+        """Send a best-effort servo setpoint, to be reached in ``duration`` seconds.
+
+        Servo targets replace rather than queue: each supersedes the last, and the driver's real-time
+        core plans a fresh profile to it under the servo limits and follows it best-effort. A target
+        is never refused for being far away, and **no collision check runs on this path**.
+
+        ``duration`` is the spacing between successive calls (``1/f`` in the ``servo(q, 1/f)``
+        pattern), which stretches the profile so the command glides between targets instead of
+        arriving early and dwelling. The controller interpolates at 125 Hz, so there is nothing to
+        gain above that rate: extra setpoints are coalesced away rather than queued.
+
+        A servo stream has no terminal condition — call `hold` to end it. Until you do, the driver
+        holds the last target and the arm never counts as being at rest.
+        """
+        self._assert_positive_duration(duration)
+        target = np.asarray(joint_configuration, dtype=float)
+        if target.shape != (FANUC_DOF,):
+            raise ValueError(f"Expected a joint configuration with shape ({FANUC_DOF},).")
+        # Reachability is deliberately not checked here: it costs time this loop does not have, and
+        # the driver's real-time core clamps a servo target into the arm's position limits anyway.
+        self._submit(lambda: self.driver.servo_j(target, duration))
+        return self._duration_action(duration)
+
+    def execute_trajectory(self, joint_trajectory: SingleArmTrajectory, sampling_frequency: float = 100) -> None:
+        """Execute a time-parameterized joint trajectory. Blocks until it finishes.
+
+        This overrides the base-class implementation, which streams a trajectory servo command by
+        servo command from Python. The FANUC driver takes a whole timeline in one submission and its
+        C++ core owns playback from there, so a late Python thread costs nothing and there is no
+        reason to keep the host in the loop. The gripper trajectory (if any) is ignored, as in the
+        base class.
+
+        The trajectory has to start where the arm is and stay inside the driver's capture envelope,
+        and its joint positions are silently clamped into the arm's limits rather than validated.
+        ``fanuc_setup.md`` next to this module lists what the driver requires of one. Velocities are
+        optional: the driver derives the playback tangents itself when the path carries none.
+
+        Args:
+            joint_trajectory: the joint trajectory to execute.
+            sampling_frequency: only used to evaluate the trajectory's constraint (if it has one),
+                *not* to resample the path. The driver plays the knots back on the controller's own
+                8 ms interpolation grid.
+
+        Raises:
+            InvalidTrajectoryException: if the trajectory is not executable, either by the
+                base-class checks or by the driver's own validation.
+            RuntimeError: if the motion did not complete, e.g. because it was preempted or the robot
+                faulted. The message carries the driver's fault reason and its operator instruction.
+        """
+        self._assert_joint_trajectory_is_executable(joint_trajectory, sampling_frequency)
+
+        times = np.asarray(joint_trajectory.times, dtype=float)
+        positions = np.asarray(joint_trajectory.path.positions, dtype=float)
+        velocities = joint_trajectory.path.velocities
+        if velocities is not None:
+            velocities = np.asarray(velocities, dtype=float)
+
+        duration = float(times[-1] - times[0])
+        times_ns = np.rint((times - times[0]) * 1e9).astype(np.int64)
+
+        try:
+            handle = self._submit(lambda: self.driver.move_trajectory(times_ns, positions, velocities))
+        except (self._fanuc.TrajectoryValidationError, self._fanuc.RejectedStartMismatch) as exception:
+            raise InvalidTrajectoryException(f"The FANUC driver refused the trajectory: {exception}") from exception
+
+        # Playback can legitimately outlast the timeline, by however long the driver allows the
+        # measured joints to confirm arrival.
+        timeout = duration + float(self.driver.policy.settle.timeout_s) + self._trajectory_timeout_margin
+        try:
+            result = handle.wait(timeout=timeout)
+        except TimeoutError as exception:
+            self.driver.stop_j()
+            raise RuntimeError(
+                f"The trajectory did not finish within {timeout:.1f}s ({duration:.1f}s of trajectory plus margin); "
+                f"the robot has been stopped. {self._fault_description()}"
+            ) from exception
+        self._assert_motion_result_is_done(result, f"trajectory of {duration:.1f}s")
+
+    def move_to_tcp_pose(
+        self, tcp_pose: HomogeneousMatrixType, joint_speed: Optional[float] = None
+    ) -> AwaitableAction:
+        """Not supported: this would need inverse kinematics."""
+        _raise_no_kinematics("move_to_tcp_pose")
+
+    def move_linear_to_tcp_pose(
+        self, tcp_pose: HomogeneousMatrixType, linear_speed: Optional[float] = None
+    ) -> AwaitableAction:
+        """Not supported: the driver has no Cartesian motion mode either."""
+        _raise_no_kinematics(
+            "move_linear_to_tcp_pose",
+            "The driver has no Cartesian motion mode, so a straight line in TCP space is a joint "
+            "trajectory you plan and hand to execute_trajectory().",
+        )
+
+    def servo_to_tcp_pose(self, tcp_pose: HomogeneousMatrixType, duration: float) -> AwaitableAction:
+        """Not supported: this would need inverse kinematics."""
+        _raise_no_kinematics(
+            "servo_to_tcp_pose",
+            "Solve the pose in your control loop and stream the joint configurations with "
+            "servo_to_joint_configuration().",
+        )
+
+    ##############
+    # kinematics #
+    ##############
+
+    def inverse_kinematics(
+        self,
+        tcp_pose: HomogeneousMatrixType,
+        joint_configuration_near: Optional[JointConfigurationType] = None,
+    ) -> Optional[JointConfigurationType]:
+        """Not supported."""
+        _raise_no_kinematics("inverse_kinematics")
+
+    def forward_kinematics(self, joint_configuration: JointConfigurationType) -> HomogeneousMatrixType:
+        """Not supported for arbitrary joint configurations."""
+        _raise_no_kinematics(
+            "forward_kinematics",
+            "For the configuration the arm is currently in, get_tcp_pose() and get_flange_pose() "
+            "return the controller's own answer; it cannot be asked about a hypothetical one.",
+        )
+
+    def is_tcp_pose_reachable(self, tcp_pose: HomogeneousMatrixType) -> bool:
+        """Not supported: the base-class implementation answers this with inverse kinematics."""
+        _raise_no_kinematics(
+            "is_tcp_pose_reachable",
+            "_is_joint_configuration_reachable() does work: it is a joint-limit check, not a kinematic one.",
+        )
+
+    def _is_joint_configuration_reachable(self, joint_configuration: JointConfigurationType) -> bool:
+        """Is the configuration within the joint position limits of the arm's profile?
+
+        These are the same limits the driver's real-time core clamps every commanded position
+        against, so a configuration this rejects is one the driver would not execute as given.
+        """
+        configuration = np.asarray(joint_configuration, dtype=float)
+        return bool(
+            configuration.shape == (FANUC_DOF,)
+            and np.all(configuration >= self._joint_lower_limits)
+            and np.all(configuration <= self._joint_upper_limits)
+        )
+
+    def start_freedrive(self) -> None:
+        """Not supported while the driver is connected."""
+        raise NotImplementedError(
+            "A FANUC is hand-guided with the buttons on the arm, but only while nothing holds the motion "
+            "group, and this driver holds it for as long as it is connected. Close the driver and use "
+            "`airo_fanuc.FanucReceiveInterface` to read joint angles while a human moves the arm: it polls "
+            "over RMI and never takes the motion group."
+        )
+
+    def stop_freedrive(self) -> None:
+        """Not supported, see `start_freedrive`."""
+        self.start_freedrive()
+
+    #################
+    # driver access #
+    #################
+
+    def stop(self) -> None:
+        """Preempt whatever is running with a limit-respecting deceleration (not part of the interface).
+
+        Takes effect within one 8 ms tick and never raises. This is the *driver's* brake, not the
+        controller's own backstop and not an emergency stop. It preempts everything submitted before
+        it, so a servo loop that keeps feeding setpoints restarts the arm a tick later: stop the loop
+        as well.
+        """
+        self.driver.stop_j()
+
+    def hold(self) -> None:
+        """Brake to rest and hold the commanded pose (not part of the interface).
+
+        This is the only way a servo stream ends, and it resolves the active motion as preempted.
+        """
+        self.driver.hold()
+
+    def is_steady(self) -> bool:
+        """Is the robot at rest and holding position? (not part of the interface)"""
+        return self.driver.is_steady()
+
+    def wait_until_steady(self, timeout: float = 5.0) -> bool:
+        """Block until the robot is at rest; return ``False`` on timeout (not part of the interface)."""
+        return self.driver.wait_until_steady(timeout)
+
+    ####################
+    # non-api methods  #
+    ####################
+
+    def _submit(self, command: Callable[[], Any]) -> Any:
+        """Run a driver motion command, converting its refusals into airo-robots exceptions."""
+        try:
+            handle = command()
+        except self._fanuc.RobotFaultedError as exception:
+            raise RuntimeError(
+                f"The FANUC robot is not commandable: {exception}. "
+                f"Recover it with `robot.driver.recover()` and, after an e-stop or an operator-required "
+                f"fault, re-arm it with `robot.driver.arm()` — deliberately, never in a retry loop."
+            ) from exception
+        self.last_motion_handle = handle
+        return handle
+
+    def _brake_to_rest(self) -> None:
+        """Bring the arm to rest so the driver will plan a point-to-point move from it.
+
+        The driver does not brake on the caller's behalf, so that it never silently preempts a motion
+        the caller did not know about. This class does brake, to match the other airo-robots
+        manipulators, and says so.
+        """
+        if self.driver.is_steady():
+            return
+        logger.warning(
+            "The FANUC arm is not at rest, so the previous motion (or servo stream) is being preempted "
+            "before this point-to-point move is planned."
+        )
+        self.driver.hold()
+        if not self.driver.wait_until_steady(self._brake_timeout):
+            raise RuntimeError(
+                f"The FANUC arm did not come to rest within {self._brake_timeout}s, so a point-to-point move "
+                f"cannot be planned from it. {self._fault_description()}"
+            )
+
+    def _motion_action(self, handle: Any, description: str) -> AwaitableAction:
+        """An AwaitableAction that completes when the driver's motion handle reaches a terminal result.
+
+        The driver never raises on a motion *outcome* — a faulted, stopped or rejected motion resolves
+        to a result instead — so an outcome other than 'done' is logged here rather than raised: the
+        action has finished either way. Read ``robot.last_motion_handle.result()`` for the verdict.
+        """
+
+        def is_motion_done() -> bool:
+            result = handle.result()
+            if result is None:
+                return False
+            if result != self._fanuc.MotionResult.DONE:
+                logger.error(f"The FANUC {description} ended as {result}. {self._fault_description()}")
+            return True
+
+        # The condition reads the driver's own lock-free motion status, so it can be polled fast.
+        return AwaitableAction(is_motion_done, default_sleep_resolution=0.005)
+
+    def _assert_motion_result_is_done(self, result: Any, description: str) -> None:
+        if result == self._fanuc.MotionResult.DONE:
+            return
+        if result == self._fanuc.MotionResult.SETTLE_TIMEOUT:
+            logger.warning(
+                f"The FANUC {description} was commanded in full, but the measured joints did not confirm "
+                f"arrival within the settle window. The arm may be stalled against something, or the settle "
+                f"tolerance may be tight for this speed."
+            )
+            return
+        raise RuntimeError(f"The FANUC {description} ended as {result}. {self._fault_description()}")
+
+    def _fault_description(self) -> str:
+        """The driver's current fault reason and the operator instruction that goes with it."""
+        state = self.driver.get_state()
+        fault = state.get("fault_reason", "unknown")
+        hint = state.get("operator_hint")
+        description = f"Driver state: {state.get('lifecycle_state')}, fault: {fault}."
+        if hint:
+            description += f" Operator instruction: {hint}"
+        return description
+
+    @staticmethod
+    def _assert_positive_speed(speed: float, parameter_name: str) -> None:
+        if speed <= 0:
+            raise ValueError(f"{parameter_name} must be greater than zero.")
+
+    @staticmethod
+    def _assert_positive_duration(duration: float) -> None:
+        if duration <= 0:
+            raise ValueError("duration must be greater than zero.")
+
+    @staticmethod
+    def _duration_action(duration: float) -> AwaitableAction:
+        action_sent_time = time.perf_counter_ns()
+        return AwaitableAction(
+            lambda: time.perf_counter_ns() - action_sent_time > duration * 1e9,
+            default_timeout=2 * duration,
+            default_sleep_resolution=0.002,
+        )
+
+    @staticmethod
+    def _convert_fanuc_pose_to_homogeneous_pose(fanuc_pose: FanucPoseType) -> HomogeneousMatrixType:
+        """Convert a FANUC ``[X, Y, Z, W, P, R]`` pose (mm, degrees) to a homogeneous matrix (m, rad).
+
+        FANUC's W/P/R are fixed-axis (extrinsic) XYZ angles, i.e. ``R = Rz(R) @ Ry(P) @ Rx(W)``, which
+        is the convention `SE3Container.from_euler_angles_and_translation` expects.
+        """
+        if fanuc_pose.shape != (6,):
+            raise ValueError(f"Expected a FANUC pose with shape (6,), received {fanuc_pose.shape}.")
+        return SE3Container.from_euler_angles_and_translation(
+            np.radians(fanuc_pose[3:]), fanuc_pose[:3] / 1000.0
+        ).homogeneous_matrix
+
+
+##########################
+# manual hardware tests  #
+##########################
+# Joint-space only: the Cartesian half of the PositionManipulator interface is not available on this
+# robot. Every motion below is relative to the configuration the arm is already in, so these run on
+# any FANUC without knowing where it is parked.
+
+
+MANUAL_TEST_JOINT_SPEED = np.radians(15.0)
+"""Leading-axis speed [rad/s] the manual tests move at: slow, for a first run on real hardware."""
+
+
+def _swing_direction(robot: Fanuc, joint_index: int, amplitude: float) -> float:
+    """Which way the joint has room to swing, so a joint parked near one of its stops swings away."""
+    configuration = robot.get_joint_configuration()
+    for direction in (1.0, -1.0):
+        target = configuration.copy()
+        target[joint_index] += direction * amplitude
+        if robot._is_joint_configuration_reachable(target):
+            return direction
+    raise RuntimeError(
+        f"J{joint_index + 1} is at {np.degrees(configuration[joint_index]):.1f} deg, which leaves no room for a "
+        f"{np.degrees(amplitude):.1f} deg swing in either direction within its limits. Move the arm away from "
+        f"its stop first, or run the tests on another joint."
+    )
+
+
+def manual_test_fanuc_move(
+    robot: Fanuc,
+    joint_index: int = 5,
+    amplitude: float = np.radians(15.0),
+    joint_speed: float = MANUAL_TEST_JOINT_SPEED,
+) -> None:
+    """Move one joint out and back with point-to-point moves."""
+    start_configuration = robot.get_joint_configuration()
+    delta = _swing_direction(robot, joint_index, amplitude) * amplitude
+    target = start_configuration.copy()
+    target[joint_index] += delta
+
+    print(f"current joint configuration (deg): {np.degrees(start_configuration).round(2)}")
+    input(
+        f"robot will move J{joint_index + 1} by {np.degrees(delta):+.1f} deg at "
+        f"{np.degrees(joint_speed):.0f} deg/s, press key to start"
+    )
+    action = robot.move_to_joint_configuration(target, joint_speed)
+    print("method returned, will now wait for the action to finish")
+    action.wait()
+    print(f"reached (deg): {np.degrees(robot.get_joint_configuration()).round(2)}")
+
+    input("robot will move back to the start configuration, press key to start")
+    robot.move_to_joint_configuration(start_configuration, joint_speed).wait()
+    print(f"back at (deg): {np.degrees(robot.get_joint_configuration()).round(2)}")
+
+
+def manual_test_fanuc_servo(
+    robot: Fanuc,
+    joint_index: int = 5,
+    amplitude: float = np.radians(5.0),
+    period: float = 4.0,
+    control_frequency: int = 50,
+) -> None:
+    """Servo one joint through a raised cosine, then end the stream with `hold`.
+
+    A raised cosine rather than a plain sine because a sine demands its peak velocity at ``t=0``,
+    which the driver's capture splice cannot deliver.
+    """
+    swing = _swing_direction(robot, joint_index, amplitude) * amplitude
+    start_configuration = robot.get_joint_configuration()
+    input(
+        f"robot will servo J{joint_index + 1} through a {np.degrees(swing):+.1f} deg raised cosine of "
+        f"{period:.1f}s at {control_frequency} Hz, press key to start"
+    )
+    target = start_configuration.copy()
+    try:
+        for step in range(int(period * control_frequency) + 1):
+            t = step / control_frequency
+            target[joint_index] = start_configuration[joint_index] + swing * (1 - np.cos(2 * np.pi * t / period)) / 2
+            robot.servo_to_joint_configuration(target, 1 / control_frequency).wait()
+    finally:
+        # Without this the driver keeps holding the last setpoint, so stopping the loop (or Ctrl-C-ing
+        # out of it) would not stop the arm.
+        robot.hold()
+        robot.wait_until_steady()
+    print(f"servo finished, back at (deg): {np.degrees(robot.get_joint_configuration()).round(2)}")
+
+
+def manual_test_fanuc_trajectory(
+    robot: Fanuc, joint_index: int = 5, amplitude: float = np.radians(15.0), duration: float = 6.0
+) -> None:
+    """Execute a raised-cosine joint trajectory that returns to where it started.
+
+    A raised cosine again: it starts and ends at rest, so its first knot is inside the driver's
+    capture envelope and its last one does not leave the arm moving. The path is anchored at the
+    *commanded* configuration, which is what the driver splices the first knot to.
+    """
+    swing = _swing_direction(robot, joint_index, amplitude) * amplitude
+    start_configuration = robot.get_commanded_joint_configuration()
+    times = np.linspace(0.0, duration, int(duration * 20) + 1)
+    positions = np.tile(start_configuration, (times.size, 1))
+    velocities = np.zeros_like(positions)
+    omega = 2 * np.pi / duration
+    positions[:, joint_index] += swing * (1 - np.cos(omega * times)) / 2
+    velocities[:, joint_index] = swing * omega * np.sin(omega * times) / 2
+
+    trajectory = SingleArmTrajectory(times, JointPathContainer(positions=positions, velocities=velocities))
+    input(
+        f"robot will execute a {duration:.1f}s trajectory that swings J{joint_index + 1} by "
+        f"{np.degrees(swing):+.1f} deg and back, press key to start"
+    )
+    robot.execute_trajectory(trajectory)
+    print(f"trajectory finished ({robot.last_motion_handle.result()}), the robot should be back where it started")
+    print(f"joint configuration (deg): {np.degrees(robot.get_joint_configuration()).round(2)}")
+
+
+def report_realtime_health(robot: Fanuc) -> None:
+    """Print how well the host held the controller's interpolation deadline during the tests.
+
+    The driver's ``examples/`` scripts report all of this in much more detail, and its
+    troubleshooting page says what a bad number means.
+    """
+    statistics = robot.driver.timing_stats()
+    if not statistics:
+        print("no timing statistics available")
+        return
+    print(
+        f"tx interval (ms): p50 {statistics['tx_interval_p50_ms']:.3f}  p99 {statistics['tx_interval_p99_ms']:.3f}  "
+        f"max {statistics['tx_interval_max_ms']:.3f}   (target {robot.driver.policy.config.itp_s * 1000:.3f})"
+    )
+    print(
+        f"slew clips: {robot.driver.get_state().get('total_slew_clips')} (non-zero means a commanded step was "
+        f"trimmed, so the executed path was not the planned one)"
+    )
+
+
+def manual_test_fanuc(robot: Fanuc, joint_index: int = 5) -> None:
+    """Run the joint-space manual tests against a FANUC robot.
+
+    ``joint_index`` is zero-based; J6 (the wrist roll) is the default because a mistake there is the
+    cheapest.
+    """
+    input("these tests will move the robot around its current configuration, make sure it is clear! Press key")
+
+    print(f"joint configuration (deg): {np.degrees(robot.get_joint_configuration()).round(2)}")
+    print(f"TCP pose (controller's own, with its active UTOOL):\n{robot.get_tcp_pose().round(4)}")
+    print(f"flange pose (streamed):\n{robot.get_flange_pose().round(4)}")
+    input("check that the printed pose and joint configuration match the pendant, press key if they do")
+
+    input("point-to-point moves will now be tested, press key to start")
+    manual_test_fanuc_move(robot, joint_index)
+
+    input("servoing will now be tested, the robot should move smoothly, press key to start")
+    manual_test_fanuc_servo(robot, joint_index)
+
+    input("trajectory execution will now be tested, press key to start")
+    manual_test_fanuc_trajectory(robot, joint_index)
+
+    print("all joint-space tests finished")
+    report_realtime_health(robot)
+
+
+def create_crx10ial_profile() -> Any:
+    """The ``RobotProfile`` of the CRX-10iA/L at AIRO, for the manual tests below.
+
+    **Copy this, do not import it into your own code:** the profile carries the limits the driver's
+    real-time core clamps against, and they are the *active configuration of one controller* rather
+    than a property of the model. Read your own arm's off its controller with
+    ``python -m airo_fanuc.controller_probe --ip <controller ip> --emit-profile``, see
+    ``fanuc_setup.md``.
+    """
+    fanuc = _import_airo_fanuc()
+    return fanuc.RobotProfile.from_degrees(
+        name="crx10ial",
+        model="FANUC CRX-10iA/L",
+        velocity_limits_deg_s=[120.0, 120.0, 180.0, 180.0, 180.0, 180.0],
+        acceleration_limits_deg_s2=[240.0, 240.0, 360.0, 360.0, 360.0, 360.0],
+        jerk_limits_deg_s3=[1920.0, 1920.0, 2880.0, 2880.0, 2880.0, 2880.0],
+        position_limits_lower_deg=[-179.999, -179.999, -270.0, -190.0, -179.999, -225.0],
+        position_limits_upper_deg=[179.999, 179.999, 270.0, 190.0, 179.999, 225.0],
+        max_payload_kg=10.0,
+        source=(
+            "velocity + position limits read from the controller's $PARAM_GROUP "
+            "(controller_probe --emit-profile); acceleration = 2x velocity and "
+            "jerk = 8x acceleration derived, not measured"
+        ),
+    )
+
+
+if __name__ == "__main__":
+    """test script for the FANUC implementation.
+    e.g. python airo-robots/airo_robots/manipulators/hardware/fanuc.py --ip_address 192.168.1.100
+    """
+    import click
+    from airo_robots.grippers.hardware.robotiq_2f85_fanuc import manually_test_fanuc_gripper
+
+    @click.command()
+    @click.option("--ip_address", default="192.168.1.100", show_default=True, help="IP address of the FANUC robot.")
+    @click.option("--gripper", is_flag=True, help="Bring up the Robotiq 2F-85 gripper and test it too.")
+    @click.option("--joint", default=6, show_default=True, type=click.IntRange(1, 6), help="Joint to move (1-6).")
+    def test_fanuc(ip_address: str, gripper: bool, joint: int) -> None:
+        """Run the manual manipulator tests against a FANUC robot."""
+        fanuc = _import_airo_fanuc()
+
+        print("Preconditions: controller in AUTO, drives powered, no active alarm, override at 100%, nothing")
+        print("else talking to the controller, and an operator at the robot with the E-stop in hand.")
+        if gripper:
+            print("The gripper will OPEN during bring-up: the driver probes the dispatcher with a benign open.")
+        input(f"about to connect to the FANUC at {ip_address}, press key to start")
+
+        # The profile is the one thing the driver will not guess: it holds the limits its real-time
+        # core clamps against. See create_crx10ial_profile() for how to get your own arm's.
+        policy = fanuc.DriverPolicy(
+            config=fanuc.DriverConfig(profile=create_crx10ial_profile()),
+            enable_gripper=gripper,
+        )
+        # Constructing the robot runs the whole bring-up ladder and blocks until the arm is
+        # commandable, or raises with a reason. Closing it (here, by leaving the `with` block) stops
+        # the arm, tears the session down and releases the controller.
+        with Fanuc(ip_address, policy) as robot:
+            manual_test_fanuc(robot, joint - 1)
+            if isinstance(robot.gripper, Robotiq2F85Fanuc):
+                manually_test_fanuc_gripper(robot.gripper)
+
+    test_fanuc()

--- a/airo-robots/airo_robots/manipulators/hardware/fanuc_setup.md
+++ b/airo-robots/airo_robots/manipulators/hardware/fanuc_setup.md
@@ -1,0 +1,205 @@
+# FANUC robot arm setup
+
+This README covers what you need to control a FANUC arm from airo-mono. The
+[airo-fanuc](https://github.com/airo-ugent/airo-fanuc) driver's own documentation is the authoritative
+source for the driver itself, and this page links to it rather than restating it. Read its
+[safety](https://github.com/airo-ugent/airo-fanuc/blob/main/docs/safety.md) and
+[portability](https://github.com/airo-ugent/airo-fanuc/blob/main/docs/portability.md) pages before a
+first bring-up.
+
+Developed and measured against a **FANUC CRX-10iA/L on an R-30iB-class controller**.
+
+## Installation
+
+```bash
+pip install "airo-robots[fanuc]"
+```
+
+The driver is **Linux only** and ships prebuilt wheels; see its
+[README](https://github.com/airo-ugent/airo-fanuc#installation) for the platforms it covers.
+
+## Controller requirements
+
+- **Controller option S636** (J519 Stream Motion and R912 RMI) — an ordered option, so check that
+  your controller has it: `python -m airo_fanuc.controller_probe --ip <controller ip>` reads the
+  ordered options off the controller, read-only, and is safe to run against a live cell.
+- **Controller in AUTO**, drives powered, E-stop released, no active alarm, general override at
+  100%. T1/T2 will connect but nothing will move.
+- **Nothing else talking to the controller**: one Stream Motion peer per controller is a hardware
+  constraint, and a second peer receives no status at all. The driver's advisory `flock` guards only
+  part of that — it enforces *one driver per host*, so a two-arm cell needs a distinct `lock_path`
+  per arm.
+
+## Network
+
+Connect the controller to the workstation over ethernet. The driver uses UDP port `60015` (Stream
+Motion) and TCP port `16001` (RMI); make sure neither is firewalled. Ping the controller before
+going further.
+
+The IP address is whatever is configured on the pendant (`MENU > SETUP > Host Comm`); `192.168.1.100`
+is the address of the cell at AIRO, not a FANUC-wide default.
+
+## Robot profile
+
+The driver ships **no arm profile** and requires one: it holds the limits its real-time core clamps
+every command against. Read your own arm's off its controller rather than typing it by hand, and see
+the driver's
+[configuration](https://github.com/airo-ugent/airo-fanuc/blob/main/docs/configuration.md) page for
+which fields the probe cannot supply:
+
+```bash
+python -m airo_fanuc.controller_probe --ip 192.168.1.100 --emit-profile
+```
+
+[`fanuc.py`](fanuc.py)'s `create_crx10ial_profile()` is the profile of the CRX-10iA/L at AIRO. Copy
+it as a starting point rather than importing it into your own code: those limits are the *active
+configuration of one controller*, not a property of the model.
+
+## Usage
+
+```python
+from airo_fanuc import DriverConfig, DriverPolicy
+from airo_robots.manipulators.hardware.fanuc import Fanuc, create_crx10ial_profile
+
+policy = DriverPolicy(config=DriverConfig(profile=create_crx10ial_profile()), enable_gripper=False)
+
+# Construct-and-go: this blocks until the arm is streaming and commandable, or raises with a reason.
+with Fanuc("192.168.1.100", policy) as robot:
+    print(robot.get_joint_configuration())      # radians
+    print(robot.get_tcp_pose())                 # the controller's own TCP pose, with its active UTOOL
+
+    q = robot.get_joint_configuration()
+    q[5] += 0.1
+    robot.move_to_joint_configuration(q).wait()
+```
+
+`DriverPolicy` and `DriverConfig` carry everything the driver's behaviour depends on; every field has
+a default except the profile. Anything this interface does not expose stays reachable on
+`robot.driver` (recovery, the ARM gate, timing statistics, the RMI session, register access).
+
+## No kinematics
+
+**The driver does no kinematics: no URDF, no forward kinematics, no inverse kinematics.** So on this
+class every Cartesian command raises `NotImplementedError`:
+
+| Method | Available |
+|---|---|
+| `get_joint_configuration`, `move_to_joint_configuration`, `servo_to_joint_configuration`, `execute_trajectory` | yes |
+| `get_tcp_pose`, `get_flange_pose` | yes — the *controller* computes these, they are not derived here |
+| `move_to_tcp_pose`, `move_linear_to_tcp_pose`, `servo_to_tcp_pose` | no |
+| `inverse_kinematics`, `forward_kinematics`, `is_tcp_pose_reachable` | no |
+| `start_freedrive` / `stop_freedrive` | no, see below |
+
+Plan in joint space with a numerical solver on a FANUC URDF — the CRX-10iA/L URDF is in
+[airo-models](https://github.com/airo-ugent/airo-models) — and command the resulting joint
+configurations. [curobo](https://curobo.org/) and [drake](https://drake.mit.edu/) both work; the
+`airo-drake` helpers used elsewhere in airo-mono (`time_parametrize_toppra`,
+`discretize_drake_joint_trajectory`) produce trajectories `execute_trajectory` accepts directly.
+
+Note that the controller's TCP pose follows the **UTOOL that is active on the pendant**. Set it
+there for the tool you have mounted, or `get_tcp_pose()` reports a point that is not your tool tip
+(on our cell the Robotiq gripper is a 175 mm offset along tool +Z).
+
+## Trajectory execution
+
+`execute_trajectory` is overridden for this robot: the base-class implementation streams a trajectory
+servo command by servo command from Python, while the FANUC driver takes the whole timeline in one
+submission and its C++ core owns playback, so a late Python thread costs nothing.
+
+What the driver requires of a trajectory (its
+[api](https://github.com/airo-ugent/airo-fanuc/blob/main/docs/api.md) page has the details):
+
+- It **starts where the arm is**, within the driver's capture window around the commanded pose. A
+  plan the arm has already partly executed cannot be joined part-way — replan it.
+- The **first knot's velocity** must be inside the capture envelope. Starting from rest always is; a
+  path that demands its peak velocity at `t=0` (a plain sine, say) is not. A raised cosine is.
+- Joint velocities stay within the profile's velocity limits (a violation is refused).
+- Joint **positions are not validated**: the core silently clamps them into the profile's position
+  limits each tick. If your planner can leave the envelope, validate the path yourself, or the
+  executed path is not the one you submitted.
+
+Velocities are optional. A path without them is handed to the driver as-is, which derives the
+playback tangents itself — one derivation, and the one that is guaranteed to satisfy the first-knot
+envelope.
+
+## Freedrive
+
+A FANUC CRX is hand-guided with the buttons on the arm, but only while nothing holds the motion
+group — and this driver holds it for as long as it is connected, so `start_freedrive()` raises.
+
+To hand-guide the arm while reading its joint angles (for hand-eye calibration, say), close the
+driver and use `airo_fanuc.FanucReceiveInterface` instead: it polls joint angles and status over
+RMI and never takes the motion group.
+
+## Gripper
+
+Our Robotiq 2F-85 is wired to the controller's tool I/O and driven through
+[`robotiq_2f85_fanuc.py`](../../grippers/hardware/robotiq_2f85_fanuc.py). With
+`DriverPolicy(enable_gripper=True)` (the default) the `Fanuc` class wraps the driver's gripper worker
+automatically, so `robot.gripper` is a ready `Robotiq2F85Fanuc`.
+
+Two things to know before you enable it: the `GRIPDISP` and `GRPRUN` teach-pendant programs must be
+installed on controller flash, and only discrete openings and force classes are reachable while
+nothing is readable. [fanuc_robotiq.md](../../grippers/hardware/fanuc_robotiq.md) covers both.
+
+## Testing
+
+To test that everything works, run the [fanuc.py](fanuc.py) script. It moves the arm around the
+configuration it is already in, so park it somewhere clear first.
+
+```bash
+python fanuc.py --ip_address 192.168.1.100
+python fanuc.py --ip_address 192.168.1.100 --gripper   # also runs the gripper tests
+```
+
+The gripper alone can be tested with
+[robotiq_2f85_fanuc.py](../../grippers/hardware/robotiq_2f85_fanuc.py):
+
+```bash
+python robotiq_2f85_fanuc.py --ip_address 192.168.1.100
+```
+
+Before either, walk the driver's own `examples/` directory once on a new cell: it is an ordered
+bring-up ladder from a no-motion connect to streamed servoing, each step ending in a PASS/FAIL
+verdict with the real-time loop's measured timing. It is a better first hardware run than anything
+here, and `--fake` runs it offline.
+
+### Without hardware
+
+The driver ships an in-process fake controller, which
+[`test/test_fanuc_fake_controller.py`](../../../test/test_fanuc_fake_controller.py) runs the same
+paths against (skipped unless the driver is installed):
+
+```bash
+pytest airo-robots/test/test_fanuc_fake_controller.py
+```
+
+To dry-run the two scripts above, serve the fake on the driver's default ports in one terminal and
+point the scripts at `127.0.0.1` in another. It implements the gripper register handshake too, so
+`--gripper` works.
+
+```python
+from airo_fanuc.testing import FakeCRXConfig, FakeCRXController
+
+controller = FakeCRXController(FakeCRXConfig(available_version=3, itp_s=0.008), sm_port=60015, rmi_bootstrap_port=16001)
+controller.start()
+controller.start_realtime(speed=1.0)
+input("fake controller up, press enter to stop")
+```
+
+## Troubleshooting
+
+The driver's
+[troubleshooting](https://github.com/airo-ugent/airo-fanuc/blob/main/docs/troubleshooting.md) page is
+symptom-first and covers what you will actually hit. What this class adds on top of it:
+
+- **`OwnershipError`** — another process holds the controller.
+- **A `RuntimeError` saying the robot is "not commandable"** — the driver's `RobotFaultedError`,
+  translated. A fault is latched, or the ARM gate is set; `robot.driver.get_state()["fault_reason"]`
+  and `["operator_hint"]` say which and what to do. After an e-stop, recovery deliberately leaves
+  motion inhibited until `robot.driver.arm()` is called: that is a human decision, never something to
+  put in a retry loop.
+- **`InvalidTrajectoryException`** — the driver's own trajectory refusal, translated. If it mentions
+  the capture window, anchor the first knot on `robot.get_commanded_joint_configuration()`.
+- **`is_steady()` never becomes `True`** — a servo stream is still holding its last target. Call
+  `robot.hold()`.

--- a/airo-robots/setup.py
+++ b/airo-robots/setup.py
@@ -12,6 +12,7 @@ setuptools.setup(
     install_requires=[
         "numpy>=2.0",
         "click",
+        "loguru",
         "airo-typing>=2026.1.0",
         "airo-spatial-algebra>=2026.1.0",
     ],
@@ -20,6 +21,9 @@ setuptools.setup(
     extras_require={
         "realman": ["Robotic_Arm"],
         "ur": ["ur-rtde>=1.5.7"],  # cf https://github.com/airo-ugent/airo-mono/issues/52
+        # The FANUC driver also drives the Robotiq 2F-85 that is mounted on our FANUC, over the
+        # controller's registers, so this extra covers Robotiq2F85Fanuc as well.
+        "fanuc": ["airo-fanuc>=0.1.0"],
         "schunk": ["bkstools"],
         "kelo": ["airo-tulip>=0.4.0"],
     },

--- a/airo-robots/test/test_fanuc.py
+++ b/airo-robots/test/test_fanuc.py
@@ -1,0 +1,426 @@
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any, List, Optional, Tuple
+
+import numpy as np
+import pytest
+from airo_robots.exceptions import InvalidTrajectoryException, RobotConfigurationException
+from airo_robots.grippers.hardware import robotiq_2f85_fanuc
+from airo_robots.grippers.hardware.robotiq_2f85_fanuc import (
+    CLOSE_FORCES,
+    FORCE_HARD,
+    FORCE_LIGHT,
+    FORCE_MEDIUM,
+    OPEN_FULL,
+    OPEN_MID,
+    OPEN_NARROW,
+    Robotiq2F85Fanuc,
+)
+from airo_robots.manipulators.hardware import fanuc
+from airo_spatial_algebra import SE3Container
+from airo_typing import JointPathContainer, SingleArmTrajectory
+
+# The fake driver below mirrors the parts of the airo-fanuc API that airo_robots.manipulators.
+# hardware.fanuc uses: radians everywhere except the Cartesian poses (millimeters and degrees),
+# getters that return None rather than raising when there is no data, and motion commands that return
+# a handle resolving to a non-raising MotionResult.
+
+
+class FakeMotionResult:
+    DONE = "done"
+    SETTLE_TIMEOUT = "settle_timeout"
+    STOPPED = "stopped"
+    FAULTED = "faulted"
+
+
+class FakeTrajectoryValidationError(Exception):
+    pass
+
+
+class FakeRejectedStartMismatch(Exception):
+    pass
+
+
+class FakeRobotFaultedError(Exception):
+    pass
+
+
+class FakeMotionHandle:
+    def __init__(self, result: str) -> None:
+        self._result = result
+
+    def result(self) -> str:
+        return self._result
+
+    def wait(self, timeout: Optional[float] = None) -> str:
+        return self._result
+
+
+@dataclass
+class FakeGripperProtocol:
+    name: str = "Robotiq 2F-85 via GRIPDISP"
+    open_modifiers: Tuple[int, ...] = (0, 1, 2)
+    close_modifiers: Tuple[int, ...] = (0, 1, 2)
+
+
+@dataclass
+class FakeProfile:
+    ndof: int = 6
+    velocity_limits: np.ndarray = field(default_factory=lambda: np.radians(np.full(6, 120.0)))
+    position_limits_lower: np.ndarray = field(default_factory=lambda: np.radians(np.full(6, -180.0)))
+    position_limits_upper: np.ndarray = field(default_factory=lambda: np.radians(np.full(6, 180.0)))
+
+    def describe(self) -> str:
+        return "fake FANUC"
+
+
+class FakeGripperWorker:
+    def __init__(self, protocol: FakeGripperProtocol) -> None:
+        self.protocol = protocol
+        self.calls: List[Tuple[str, int]] = []
+        self.last_result: dict = {"success": True, "message": "ok"}
+
+    def open_gripper(self, open_state: Optional[int] = None) -> None:
+        self.calls.append(("open", 0 if open_state is None else open_state))
+
+    def close_gripper(self, close_force: Optional[int] = None) -> None:
+        self.calls.append(("close", 1 if close_force is None else close_force))
+
+
+class FakeFanucDriver:
+    def __init__(self, ip: str, policy: Any) -> None:
+        self.ip = ip
+        self.policy = policy
+        self.gripper = FakeGripperWorker(policy.gripper_protocol) if policy.enable_gripper else None
+        self.q_measured = np.zeros(6)
+        self.q_commanded = np.zeros(6)
+        self.tcp_pose: Optional[np.ndarray] = np.array([500.0, 0.0, 300.0, 0.0, 0.0, 90.0])
+        self.flange_pose: Optional[np.ndarray] = np.array([325.0, 0.0, 300.0, 0.0, 0.0, 90.0])
+        self.wrench: Optional[np.ndarray] = None
+        self.steady = True
+        self.motion_result = FakeMotionResult.DONE
+        self.raise_on_submit: Optional[Exception] = None
+        self.calls: List[Tuple[Any, ...]] = []
+        self.closed = False
+
+    # -- state ---------------------------------------------------------
+    def get_joint_configuration(self) -> Optional[np.ndarray]:
+        return self.q_measured
+
+    def get_state(self) -> dict:
+        return {
+            "q_meas": self.q_measured.tolist(),
+            "q_cmd": self.q_commanded.tolist(),
+            "rx_mono_ns": 1,
+            "lifecycle_state": "streaming",
+            "fault_reason": "none",
+            "operator_hint": None,
+        }
+
+    def get_tcp_pose(self) -> Optional[np.ndarray]:
+        return self.tcp_pose
+
+    def get_flange_pose(self) -> Optional[np.ndarray]:
+        return self.flange_pose
+
+    def get_wrench(self) -> Optional[np.ndarray]:
+        return self.wrench
+
+    # -- motion --------------------------------------------------------
+    def move_j(self, q: np.ndarray, joint_speed: Optional[float] = None) -> FakeMotionHandle:
+        if self.raise_on_submit is not None:
+            raise self.raise_on_submit
+        self.calls.append(("move_j", np.asarray(q), joint_speed))
+        self.q_commanded = np.asarray(q, dtype=float)
+        self.q_measured = np.asarray(q, dtype=float)
+        return FakeMotionHandle(self.motion_result)
+
+    def move_trajectory(self, times: Any, q: Any, qd: Any = None) -> FakeMotionHandle:
+        if self.raise_on_submit is not None:
+            raise self.raise_on_submit
+        self.calls.append(
+            ("move_trajectory", np.asarray(times), np.asarray(q), None if qd is None else np.asarray(qd))
+        )
+        return FakeMotionHandle(self.motion_result)
+
+    def servo_j(self, q: np.ndarray, duration: float) -> FakeMotionHandle:
+        self.calls.append(("servo_j", np.asarray(q), duration))
+        self.steady = False
+        return FakeMotionHandle(self.motion_result)
+
+    def stop_j(self) -> None:
+        self.calls.append(("stop_j",))
+
+    def hold(self) -> None:
+        self.calls.append(("hold",))
+        self.steady = True
+
+    def is_steady(self) -> bool:
+        return self.steady
+
+    def wait_until_steady(self, timeout: float = 5.0) -> bool:
+        return self.steady
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _fake_policy(enable_gripper: bool = False) -> Any:
+    return SimpleNamespace(
+        config=SimpleNamespace(profile=FakeProfile()),
+        settle=SimpleNamespace(timeout_s=2.0),
+        enable_gripper=enable_gripper,
+        gripper_protocol=FakeGripperProtocol(),
+    )
+
+
+def _fake_module() -> Any:
+    return SimpleNamespace(
+        FanucDriver=FakeFanucDriver,
+        MotionResult=FakeMotionResult,
+        TrajectoryValidationError=FakeTrajectoryValidationError,
+        RejectedStartMismatch=FakeRejectedStartMismatch,
+        RobotFaultedError=FakeRobotFaultedError,
+    )
+
+
+def _make_robot(monkeypatch: pytest.MonkeyPatch, enable_gripper: bool = False) -> fanuc.Fanuc:
+    policy = _fake_policy(enable_gripper)
+    monkeypatch.setattr(fanuc, "_import_airo_fanuc", _fake_module)
+    monkeypatch.setattr(
+        robotiq_2f85_fanuc,
+        "_import_airo_fanuc_gripper",
+        lambda: SimpleNamespace(ROBOTIQ_2F85=policy.gripper_protocol),
+    )
+    return fanuc.Fanuc("192.168.1.100", policy)
+
+
+@pytest.fixture
+def robot(monkeypatch: pytest.MonkeyPatch) -> fanuc.Fanuc:
+    return _make_robot(monkeypatch)
+
+
+@pytest.fixture
+def robot_with_gripper(monkeypatch: pytest.MonkeyPatch) -> fanuc.Fanuc:
+    return _make_robot(monkeypatch, enable_gripper=True)
+
+
+@pytest.fixture
+def gripper(robot_with_gripper: fanuc.Fanuc) -> Robotiq2F85Fanuc:
+    """The gripper the driver brought up, narrowed from ``Optional`` once for every gripper test."""
+    assert isinstance(robot_with_gripper.gripper, Robotiq2F85Fanuc)
+    return robot_with_gripper.gripper
+
+
+def test_specs_and_state_use_airo_units(robot: fanuc.Fanuc) -> None:
+    assert robot.manipulator_specs.dof == 6
+    assert robot.manipulator_specs.max_joint_speeds == pytest.approx(np.radians(np.full(6, 120.0)))
+
+    robot.driver.q_measured = np.radians(np.asarray([0.0, 30.0, -90.0, 0.0, 45.0, 180.0]))
+    assert robot.get_joint_configuration() == pytest.approx(robot.driver.q_measured)
+
+    # The FANUC controller reports millimeters and degrees, with W/P/R as fixed-axis XYZ angles.
+    expected_pose = SE3Container.from_euler_angles_and_translation(
+        np.radians(np.asarray([0.0, 0.0, 90.0])), np.asarray([0.5, 0.0, 0.3])
+    ).homogeneous_matrix
+    assert robot.get_tcp_pose() == pytest.approx(expected_pose)
+    assert robot.get_flange_pose()[:3, 3] == pytest.approx([0.325, 0.0, 0.3])
+
+
+def test_state_getters_raise_rather_than_returning_a_substitute(robot: fanuc.Fanuc) -> None:
+    robot.driver.tcp_pose = None
+    with pytest.raises(RuntimeError, match="TCP pose"):
+        robot.get_tcp_pose()
+
+    # No force block on the wire (a v3 controller) is a raise, not a zero wrench.
+    with pytest.raises(RuntimeError, match="force telemetry"):
+        robot.get_wrench()
+
+    robot.driver.wrench = np.arange(6, dtype=float)
+    assert robot.get_wrench() == pytest.approx(np.arange(6))
+
+
+def test_move_to_joint_configuration_plans_with_move_j(robot: fanuc.Fanuc) -> None:
+    target = np.radians(np.asarray([10.0, 20.0, 30.0, 40.0, 50.0, 60.0]))
+    action = robot.move_to_joint_configuration(target, joint_speed=0.5)
+
+    method, joints, speed = robot.driver.calls[-1]
+    assert method == "move_j"
+    assert joints == pytest.approx(target)
+    assert speed == 0.5
+    assert action.wait().name == "SUCCEEDED"
+
+
+def test_move_to_joint_configuration_brakes_a_moving_arm_first(robot: fanuc.Fanuc) -> None:
+    # The driver refuses to plan a point-to-point move from a moving anchor, so a servo stream (which
+    # never ends by itself) has to be ended before the next move can be planned.
+    robot.servo_to_joint_configuration(np.zeros(6), 0.02)
+    assert not robot.driver.is_steady()
+
+    robot.move_to_joint_configuration(np.zeros(6))
+    assert [call[0] for call in robot.driver.calls] == ["servo_j", "hold", "move_j"]
+
+
+def test_out_of_limit_configurations_are_refused(robot: fanuc.Fanuc) -> None:
+    assert robot._is_joint_configuration_reachable(np.zeros(6))
+    assert not robot._is_joint_configuration_reachable(np.radians(np.full(6, 200.0)))
+    assert not robot._is_joint_configuration_reachable(np.zeros(7))
+
+    with pytest.raises(RobotConfigurationException):
+        robot.move_to_joint_configuration(np.radians(np.full(6, 200.0)))
+    assert robot.driver.calls == []
+
+
+def test_servo_passes_the_setpoint_and_duration_through(robot: fanuc.Fanuc) -> None:
+    target = np.radians(np.ones(6))
+    robot.servo_to_joint_configuration(target, 0.02)
+
+    method, joints, duration = robot.driver.calls[-1]
+    assert method == "servo_j"
+    assert joints == pytest.approx(target)
+    assert duration == 0.02
+
+    with pytest.raises(ValueError):
+        robot.servo_to_joint_configuration(np.zeros(5), 0.02)
+    with pytest.raises(ValueError):
+        robot.servo_to_joint_configuration(target, 0.0)
+
+
+def test_cartesian_and_kinematics_methods_point_at_a_numerical_solver(robot: fanuc.Fanuc) -> None:
+    pose = np.eye(4)
+    for call in (
+        lambda: robot.move_to_tcp_pose(pose),
+        lambda: robot.move_linear_to_tcp_pose(pose),
+        lambda: robot.servo_to_tcp_pose(pose, 0.02),
+        lambda: robot.inverse_kinematics(pose),
+        lambda: robot.forward_kinematics(np.zeros(6)),
+        lambda: robot.is_tcp_pose_reachable(pose),
+    ):
+        with pytest.raises(NotImplementedError, match="airo-models"):
+            call()
+
+    with pytest.raises(NotImplementedError, match="FanucReceiveInterface"):
+        robot.start_freedrive()
+    with pytest.raises(NotImplementedError, match="FanucReceiveInterface"):
+        robot.stop_freedrive()
+
+
+def _trajectory(with_velocities: bool = True) -> SingleArmTrajectory:
+    times = np.linspace(0.0, 2.0, 21)
+    positions = np.zeros((times.size, 6))
+    positions[:, 5] = np.radians(10.0) * (1 - np.cos(np.pi * times / 2.0)) / 2
+    velocities = np.zeros_like(positions)
+    velocities[:, 5] = np.radians(10.0) * (np.pi / 2.0) * np.sin(np.pi * times / 2.0) / 2
+    path = JointPathContainer(positions=positions, velocities=velocities if with_velocities else None)
+    return SingleArmTrajectory(times, path)
+
+
+def test_execute_trajectory_submits_the_whole_timeline_at_once(robot: fanuc.Fanuc) -> None:
+    trajectory = _trajectory()
+    robot.execute_trajectory(trajectory)
+
+    # One submission, not a servo command per interpolation step.
+    assert [call[0] for call in robot.driver.calls] == ["move_trajectory"]
+    _, times_ns, positions, velocities = robot.driver.calls[-1]
+    assert times_ns.dtype == np.int64
+    assert times_ns[0] == 0 and times_ns[-1] == 2_000_000_000
+    assert positions == pytest.approx(trajectory.path.positions)
+    assert velocities == pytest.approx(trajectory.path.velocities)
+
+
+def test_execute_trajectory_leaves_missing_velocities_to_the_driver(robot: fanuc.Fanuc) -> None:
+    # airo-mono's velocities are optional and the driver derives the playback tangents itself, so a
+    # path without them is handed over as-is rather than differentiated here: one derivation, and the
+    # one that is guaranteed to land inside the driver's first-knot capture envelope.
+    robot.execute_trajectory(_trajectory(with_velocities=False))
+
+    _, _, _, velocities = robot.driver.calls[-1]
+    assert velocities is None
+
+
+def test_execute_trajectory_reports_a_refusal_and_a_failed_motion(robot: fanuc.Fanuc) -> None:
+    robot.driver.raise_on_submit = FakeRejectedStartMismatch("first knot outside the capture window")
+    with pytest.raises(InvalidTrajectoryException, match="capture window"):
+        robot.execute_trajectory(_trajectory())
+
+    robot.driver.raise_on_submit = None
+    robot.driver.motion_result = FakeMotionResult.FAULTED
+    with pytest.raises(RuntimeError, match="faulted"):
+        robot.execute_trajectory(_trajectory())
+
+    # A trajectory that was commanded in full but did not confirm arrival is a warning, not a failure.
+    robot.driver.motion_result = FakeMotionResult.SETTLE_TIMEOUT
+    robot.execute_trajectory(_trajectory())
+
+
+def test_a_faulted_robot_is_reported_with_its_operator_instruction(robot: fanuc.Fanuc) -> None:
+    robot.driver.raise_on_submit = FakeRobotFaultedError("e_stop")
+    with pytest.raises(RuntimeError, match="not commandable"):
+        robot.move_to_joint_configuration(np.zeros(6))
+
+
+def test_the_driver_gripper_is_wrapped_automatically(robot_with_gripper: fanuc.Fanuc) -> None:
+    assert isinstance(robot_with_gripper.gripper, Robotiq2F85Fanuc)
+
+
+def test_gripper_snaps_widths_to_the_reachable_buckets(
+    robot_with_gripper: fanuc.Fanuc, gripper: Robotiq2F85Fanuc
+) -> None:
+    worker = robot_with_gripper.driver.gripper
+
+    gripper.open().wait()
+    assert worker.calls[-1] == ("open", OPEN_FULL)
+
+    gripper.move(0.058).wait()  # closest to the ~60 mm bucket
+    assert worker.calls[-1] == ("open", OPEN_MID)
+    assert gripper.last_commanded_width == pytest.approx(0.060)
+
+    gripper.move(0.030).wait()  # closest to the ~35 mm bucket
+    assert worker.calls[-1] == ("open", OPEN_NARROW)
+
+    gripper.close().wait()
+    assert worker.calls[-1] == ("close", FORCE_MEDIUM)
+    assert gripper.last_result == {"success": True, "message": "ok"}
+
+
+def test_gripper_force_is_rounded_to_a_force_class(robot_with_gripper: fanuc.Fanuc, gripper: Robotiq2F85Fanuc) -> None:
+    worker = robot_with_gripper.driver.gripper
+
+    gripper.move(0.0, force=30.0)
+    assert worker.calls[-1] == ("close", FORCE_LIGHT)
+    assert gripper.max_grasp_force == CLOSE_FORCES[FORCE_LIGHT]
+
+    gripper.max_grasp_force = 1000.0  # clipped to the gripper's maximum, then to the nearest class
+    assert gripper.close_force_class == FORCE_HARD
+    gripper.close()
+    assert worker.calls[-1] == ("close", FORCE_HARD)
+
+    with pytest.raises(ValueError):
+        gripper.close_force_class = 7
+
+
+def test_gripper_refuses_what_a_fanuc_cannot_do(gripper: Robotiq2F85Fanuc) -> None:
+    def set_speed() -> None:
+        gripper.speed = 0.1
+
+    for call in (
+        lambda: gripper.move(0.05, speed=0.1),
+        gripper.get_current_width,
+        gripper.is_an_object_grasped,
+        lambda: gripper.speed,
+        set_speed,
+    ):
+        with pytest.raises(NotImplementedError):
+            call()
+
+
+def test_gripper_requires_a_driver_that_brought_one_up(robot: fanuc.Fanuc) -> None:
+    assert robot.gripper is None
+    with pytest.raises(ValueError, match="enable_gripper"):
+        Robotiq2F85Fanuc(robot.driver)
+
+
+def test_close_is_idempotent(robot: fanuc.Fanuc) -> None:
+    robot.close()
+    assert robot.driver.closed
+    robot.close()

--- a/airo-robots/test/test_fanuc_fake_controller.py
+++ b/airo-robots/test/test_fanuc_fake_controller.py
@@ -1,0 +1,175 @@
+"""Integration tests for the FANUC implementation against airo-fanuc's in-process fake controller.
+
+These run the real driver — its validation, its capture gate, its real-time core and its register
+gripper handshake — against a fake FANUC controller instead of a real one, so they cover what the
+mocked tests in ``test_fanuc.py`` cannot. They are skipped unless the optional driver is installed
+(``pip install "airo-robots[fanuc]"``).
+
+They need no hardware, but they do run a 125 Hz real-time loop and a few seconds of simulated
+motion, so they are slower than the rest of the suite.
+"""
+
+import tempfile
+from pathlib import Path
+from typing import Iterator, Tuple
+
+import numpy as np
+import pytest
+
+pytest.importorskip("airo_fanuc", reason="the FANUC implementation needs the optional airo-fanuc driver")
+
+from airo_fanuc import DriverConfig, DriverPolicy  # noqa: E402
+from airo_fanuc.testing import FakeCRXConfig, FakeCRXController  # noqa: E402
+from airo_robots.exceptions import InvalidTrajectoryException  # noqa: E402
+from airo_robots.grippers.hardware.robotiq_2f85_fanuc import (  # noqa: E402
+    FORCE_HARD,
+    OPEN_MID,
+    OPEN_WIDTHS,
+    Robotiq2F85Fanuc,
+)
+from airo_robots.manipulators.hardware.fanuc import Fanuc, create_crx10ial_profile  # noqa: E402
+from airo_typing import JointPathContainer, SingleArmTrajectory  # noqa: E402
+
+JOINT = 5  # J6, the wrist roll: the cheapest joint to be wrong about, on a fake or on a real arm.
+
+
+@pytest.fixture(scope="module")
+def robot() -> Iterator[Fanuc]:
+    controller = FakeCRXController(FakeCRXConfig(available_version=3, itp_s=0.008))
+    controller.start()
+    controller.start_realtime(speed=1.0)
+    policy = DriverPolicy(
+        config=DriverConfig(
+            profile=create_crx10ial_profile(),
+            sm_port=controller.sm_port,
+            rmi_port=controller.rmi_port,
+            sm_version=3,
+        ),
+        enable_gripper=True,
+        lock_path=str(Path(tempfile.gettempdir()) / "airo-fanuc-airo-robots-test.lock"),
+    )
+    try:
+        with Fanuc("127.0.0.1", policy) as fanuc_robot:
+            yield fanuc_robot
+    finally:
+        controller.stop_realtime()
+        controller.close()
+
+
+def _raised_cosine(
+    start_configuration: np.ndarray, amplitude: float, duration: float, knots: int = 121
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """A path that starts and ends at rest, so its first knot is inside the capture envelope."""
+    times = np.linspace(0.0, duration, knots)
+    omega = 2 * np.pi / duration
+    positions = np.tile(start_configuration, (times.size, 1))
+    velocities = np.zeros_like(positions)
+    positions[:, JOINT] += amplitude * (1 - np.cos(omega * times)) / 2
+    velocities[:, JOINT] = amplitude * omega * np.sin(omega * times) / 2
+    return times, positions, velocities
+
+
+def test_bringup_reports_a_streaming_robot(robot: Fanuc) -> None:
+    state = robot.driver.get_state()
+    assert state["lifecycle_state"] == "streaming"
+    assert robot.is_steady()
+    assert robot.get_joint_configuration().shape == (6,)
+    assert robot.get_tcp_pose().shape == (4, 4)
+    # The gripper worker the driver brought up is wrapped automatically.
+    assert isinstance(robot.gripper, Robotiq2F85Fanuc)
+
+
+def test_move_to_joint_configuration_arrives(robot: Fanuc) -> None:
+    start_configuration = robot.get_commanded_joint_configuration()
+    target = start_configuration.copy()
+    target[JOINT] += np.radians(10.0)
+
+    robot.move_to_joint_configuration(target, np.radians(15.0)).wait()
+    assert robot.get_commanded_joint_configuration() == pytest.approx(target, abs=np.radians(0.5))
+
+    robot.move_to_joint_configuration(start_configuration, np.radians(15.0)).wait()
+
+
+def test_a_move_after_a_servo_stream_brakes_first(robot: Fanuc) -> None:
+    start_configuration = robot.get_commanded_joint_configuration()
+    target = start_configuration.copy()
+    target[JOINT] += np.radians(2.0)
+
+    robot.servo_to_joint_configuration(target, 0.05).wait()
+    # A servo stream has no terminal condition, so the arm is not at rest afterwards and the driver
+    # would refuse to plan a point-to-point move from it.
+    assert not robot.is_steady()
+
+    robot.move_to_joint_configuration(start_configuration, np.radians(15.0)).wait()
+    assert robot.is_steady()
+
+
+def test_execute_trajectory_runs_the_whole_path(robot: Fanuc) -> None:
+    times, positions, velocities = _raised_cosine(robot.get_commanded_joint_configuration(), np.radians(10.0), 4.0)
+    robot.execute_trajectory(SingleArmTrajectory(times, JointPathContainer(positions, velocities)))
+    assert robot.last_motion_handle.result().name == "DONE"
+    assert robot.get_commanded_joint_configuration() == pytest.approx(positions[-1], abs=np.radians(0.5))
+
+
+def test_execute_trajectory_without_velocities_is_accepted_by_the_driver(robot: Fanuc) -> None:
+    # The estimated first-knot velocity has to stay inside the driver's capture envelope, or the
+    # submission is refused; this is the check that the estimate is good enough to be usable.
+    times, positions, _ = _raised_cosine(robot.get_commanded_joint_configuration(), np.radians(10.0), 4.0)
+    robot.execute_trajectory(SingleArmTrajectory(times, JointPathContainer(positions)))
+    assert robot.last_motion_handle.result().name == "DONE"
+
+
+def test_a_trajectory_the_driver_refuses_raises_an_airo_robots_exception(robot: Fanuc) -> None:
+    # A plain sine demands its peak velocity at t=0, which the capture splice cannot deliver. The
+    # driver's typed refusal has to reach the caller as an airo-robots exception.
+    start_configuration = robot.get_commanded_joint_configuration()
+    times = np.linspace(0.0, 4.0, 121)
+    omega = 2 * np.pi / 4.0
+    positions = np.tile(start_configuration, (times.size, 1))
+    velocities = np.zeros_like(positions)
+    positions[:, JOINT] += np.radians(20.0) * np.sin(omega * times)
+    velocities[:, JOINT] = np.radians(20.0) * omega * np.cos(omega * times)
+
+    with pytest.raises(InvalidTrajectoryException):
+        robot.execute_trajectory(SingleArmTrajectory(times, JointPathContainer(positions, velocities)))
+
+
+def test_a_preempted_trajectory_is_reported_and_leaves_the_arm_usable(robot: Fanuc) -> None:
+    import threading
+
+    start_configuration = robot.get_commanded_joint_configuration()
+    times, positions, velocities = _raised_cosine(start_configuration, np.radians(20.0), 6.0)
+
+    stop_timer = threading.Timer(1.5, robot.stop)
+    stop_timer.start()
+    try:
+        with pytest.raises(RuntimeError, match="STOPPED"):
+            robot.execute_trajectory(SingleArmTrajectory(times, JointPathContainer(positions, velocities)))
+    finally:
+        stop_timer.cancel()
+
+    robot.hold()
+    assert robot.wait_until_steady()
+    robot.move_to_joint_configuration(start_configuration, np.radians(15.0)).wait()
+    assert robot.get_commanded_joint_configuration() == pytest.approx(start_configuration, abs=np.radians(0.5))
+
+
+def test_the_gripper_dispatcher_handshake_completes(robot: Fanuc) -> None:
+    gripper = robot.gripper
+    assert isinstance(gripper, Robotiq2F85Fanuc)
+
+    gripper.open().wait()
+    assert gripper.last_result is not None and gripper.last_result["success"]
+
+    # An in-between width snaps to the nearest bucket the dispatcher implements.
+    gripper.move(OPEN_WIDTHS[OPEN_MID] - 0.002).wait()
+    assert gripper.last_commanded_width == pytest.approx(OPEN_WIDTHS[OPEN_MID])
+    assert gripper.last_result is not None and gripper.last_result["success"]
+
+    gripper.max_grasp_force = gripper.gripper_specs.max_force
+    assert gripper.close_force_class == FORCE_HARD
+    gripper.close().wait()
+    assert gripper.last_result is not None and gripper.last_result["success"]
+
+    gripper.open().wait()
+    assert gripper.last_result is not None and gripper.last_result["success"]


### PR DESCRIPTION
Adds FANUC support to `airo-robots`, built on the [airo-fanuc](https://github.com/airo-ugent/airo-fanuc) driver (Stream Motion + RMI), which is now on PyPI.

## What's added

- **`Fanuc`** — a `PositionManipulator` for FANUC robots. Joint-space control, `get_tcp_pose` and `execute_trajectory` are supported.
- **`Robotiq2F85Fanuc`** — a `ParallelPositionGripper` for a Robotiq 2F-85 wired to a FANUC controller and actuated over the controller's registers.

Both install with `pip install "airo-robots[fanuc]"`. The vendor SDK stays optional, following the pattern already used for UR, RealMan and Schunk: instantiating a class without its SDK raises an `ImportError` naming the extra.

## Two things a FANUC cannot do

These shape the whole implementation, so they are worth stating up front rather than discovering at runtime:

1. **The driver does no kinematics.** Every Cartesian and kinematics method raises `NotImplementedError` pointing at a numerical solver on a FANUC URDF (airo-models). `get_tcp_pose` works because the *controller* reports its own TCP pose, with its active UTOOL.
2. **The controller has no gripper API.** The driver writes registers that a teach-pendant program (`GRIPDISP`) watches; the only readable state is whether that program finished. So only discrete openings and force classes are reachable — `move` snaps a requested width to the nearest bucket and logs that it did — and `get_current_width` / `is_an_object_grasped` refuse with an actionable message.

Each refusal explains what to use instead, and both `fanuc_setup.md` and `fanuc_robotiq.md` document what the hardware needs before any of this can drive it.

## Also in here

`loguru` is now a declared `airo-robots` dependency. It was already imported by the shipped hardware implementations but only installed as a side effect of `airo-camera-toolkit`.

## Testing

**Unit / integration:** 56 tests pass (`make pytest airo-robots/`), including a suite against the driver's fake controller. The FANUC tests skip cleanly when `airo-fanuc` is not installed, so CI without the extra stays green. mypy and pre-commit are clean.

**Hardware,** against the CRX-10iA/L at AIRO with `airo-fanuc==0.1.0` from PyPI:

- `controller_probe` confirms option S636, the Stream Motion (J519) and RMI (R912) TP programs, and `GRIPDISP` + `GRPRUN` on controller flash.
- Both manual test suites (`python airo_robots/manipulators/hardware/fanuc.py --ip_address <ip>`, with and without `--gripper`) pass end to end: point-to-point, servoing, trajectory execution (`MotionResult.DONE`), and all gripper buckets, snapping, and force classes.
- Stream Motion timing held **8.000 ms p50** against the 8 ms ITP target with **0 slew clips**, so no commanded step was trimmed.
- `create_crx10ial_profile()` matches what the controller reports for itself via `controller_probe --emit-profile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
